### PR TITLE
Further-simply & enable e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,10 @@ jobs:
           cd build
           ./tests.sh -L unit
         shell: bash
+
+      - name: "Run all other (e2e) tests"
+        run: |
+          set -ex
+          cd build
+          ./tests.sh -LE unit
+        shell: bash


### PR DESCRIPTION
I have failed to understand the removed add_record/check_record testing.
- it requests records but the ones added via `/internal/add` are not signed automatically
- even if being force-resigned, they run on a service with a different `/configure`d service name, so the instance refuses to sign those

Long story short
- suspect to never have worked
- deleted

Moving forward to more clean-up and 2 e2e-testing for aDNS instances with delegation in further PRs.