### PR TITLE
Minor devcontainer and CI changes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
         "ms-python.python",
         "ms-vscode.cpptools",
         "github.copilot",
-        "ms-vscode.cmake-tools"
+        "ms-vscode.cmake-tools",
+        "xaver.clang-format"
       ]
     },
     "settings": {

--- a/scripts/check-cmake-format.sh
+++ b/scripts/check-cmake-format.sh
@@ -34,7 +34,6 @@ if [ ! -f "scripts/env/bin/activate" ]
 fi
 
 source scripts/env/bin/activate
-pip install -U pip
 pip install cmake_format==0.6.11 1>/dev/null
 
 unformatted_files=""

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -76,7 +76,6 @@ if [ ! -f "scripts/env/bin/activate" ]
 fi
 
 source scripts/env/bin/activate
-pip install -U pip
 pip install -U wheel black mypy ruff 1>/dev/null
 endgroup
 


### PR DESCRIPTION
* Added clang-format extension to devcontainer
* `pip install -U pip` fails because it's been install via `tdnf`, and wants to be updated via `tdnf`. This's actually copy-pasted from CCF code, not sure why we have it there.