### PR TITLE
Remove delegation (and related bits)

### DIFF
--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -180,17 +180,6 @@ namespace aDNS
     Resolver::RegistrationRequest, csr, contact, node_information);
   DECLARE_JSON_OPTIONAL_FIELDS(
     Resolver::RegistrationRequest, configuration_receipt);
-
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Resolver::DelegationRequest);
-  DECLARE_JSON_REQUIRED_FIELDS(
-    Resolver::DelegationRequest,
-    subdomain,
-    csr,
-    contact,
-    dnskey_records,
-    node_information);
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    Resolver::DelegationRequest, configuration_receipt);
 }
 
 namespace ccfdns

--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -167,7 +167,7 @@ namespace aDNS
     service_ca,
     node_addresses);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    Resolver::Configuration, alternative_names, parent_base_url, fixed_zsk);
+    Resolver::Configuration, alternative_names, fixed_zsk);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Resolver::RegistrationInformation);
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -51,12 +51,6 @@ namespace ccfdns
     using Out = void;
   };
 
-  struct RegisterDelegation
-  {
-    using In = aDNS::Resolver::DelegationRequest;
-    using Out = void;
-  };
-
   struct SetCertificate
   {
     struct In

--- a/include/keys.h
+++ b/include/keys.h
@@ -23,17 +23,4 @@ namespace ccfdns
 
   using PrivateDNSKeys = ccf::ServiceMap<RFC1035::Name, ZoneKeyInfo>;
   const std::string private_dnskey_table_name = "private:dnskey_table_name";
-
-  // We keep keys in vectors, ordered by creation-time.
-  // The private vector keeps only the active signing key [0] and the next ones
-  // [1+] The public vector may keep additional old public keys for
-  // discoverability
-
-  using CertificatePrivateKeys = ccf::ServiceValue<std::vector<std::string>>;
-  const std::string certificate_private_key_table_name =
-    "private:certificate_private_key_table_name";
-
-  using RootCertificates = ccf::ServiceValue<std::vector<std::string>>;
-  const std::string root_certificate_table_name =
-    "private:root_certificate_name";
 }

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -174,19 +174,6 @@ namespace aDNS
       std::optional<std::string> configuration_receipt;
     };
 
-    struct DelegationRequest
-    {
-      Name subdomain; // must be a direct subdomain of the parent zone; subzone
-                      // a better name?
-      std::vector<uint8_t> csr; // used to run ACME (?)
-      std::vector<std::string> contact; // isn't it part of the configuration?
-      std::map<std::string, NodeInfo>
-        node_information; // used to create NS and glue records
-      std::vector<aDNS::ResourceRecord>
-        dnskey_records; // used to produce DS records
-      std::optional<std::string> configuration_receipt;
-    };
-
     struct Resolution
     {
       RFC1035::ResponseCode response_code = RFC1035::ResponseCode::NO_ERROR;

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -128,10 +128,6 @@ namespace aDNS
 
       std::optional<std::vector<Name>> alternative_names;
 
-      // this field is set when the origin is delegated from a larger attested
-      // zone why an URL?
-      std::optional<std::string> parent_base_url;
-
       std::vector<std::string> contact;
 
       uint32_t default_ttl = 86400;
@@ -256,8 +252,6 @@ namespace aDNS
 
     virtual bool origin_exists(const Name& name) const = 0;
 
-    virtual bool is_delegated(const Name& origin, const Name& name) const = 0;
-
     virtual void sign(const Name& origin);
 
     virtual void add(const Name& origin, const ResourceRecord& rr) = 0;
@@ -291,12 +285,6 @@ namespace aDNS
     virtual bool evaluate_service_registration_policy(
       const std::string& data) const = 0;
 
-    virtual void register_delegation(const DelegationRequest& req);
-
-    virtual std::vector<std::string> delegation_policy() const = 0;
-    virtual void set_delegation_policy(const std::string& new_policy) = 0;
-    virtual bool evaluate_delegation_policy(const std::string& data) const = 0;
-
     virtual Configuration get_configuration() const = 0;
     virtual void set_configuration(const Configuration& cfg) = 0;
 
@@ -304,9 +292,6 @@ namespace aDNS
 
     virtual void save_service_registration_request(
       const Name& name, const RegistrationRequest& rr) = 0;
-
-    virtual void save_delegation_request(
-      const Name& name, const DelegationRequest& rr) = 0;
 
     virtual std::map<std::string, NodeInfo> get_node_information() = 0;
 

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -905,9 +905,6 @@ namespace ccfdns
           my_name.pop_back();
       }
 
-      // TODO remove this?
-      create_certificate_signing_key("");
-
       return reginfo;
     }
 
@@ -1194,44 +1191,6 @@ namespace ccfdns
       std::string pem_str(pem_data, pem_length);
       BIO_free(bio);
       return pem_str;
-    }
-
-    void create_certificate_signing_key(std::string alg)
-    {
-      try
-      {
-        check_context();
-        uint32_t now = get_fresh_time();
-
-        EVP_PKEY* pkey = create_private_key();
-        std::string pem_str = private_key_to_pem(pkey);
-
-        auto private_key_table = rwtx().template rw<CertificatePrivateKeys>(
-          certificate_private_key_table_name);
-        auto private_keys =
-          private_key_table->get().value_or(std::vector<std::string>());
-        private_keys.push_back(pem_str);
-        private_key_table->put(private_keys);
-
-        X509* x509 = create_root_certificate(pkey);
-        std::string pem_str_cert = certificate_to_pem(x509);
-
-        auto root_certificate_table =
-          rwtx().template rw<RootCertificates>(root_certificate_table_name);
-        auto root_certificates =
-          root_certificate_table->get().value_or(std::vector<std::string>());
-        root_certificates.push_back(pem_str_cert);
-        root_certificate_table->put(root_certificates);
-
-        CCF_APP_INFO("aDNS: Create root certificate\n{}", pem_str_cert);
-
-        return;
-      }
-      catch (std::exception& ex)
-      {
-        CCF_APP_INFO("Certificate signing key gen fails with {}", ex.what());
-        return;
-      }
     }
 
   protected:

--- a/tests/adns_service.py
+++ b/tests/adns_service.py
@@ -86,7 +86,6 @@ class aDNSConfig(dict):
         nsec3_hash_algorithm,
         nsec3_hash_iterations,
         nsec3_salt_length,
-        parent_base_url,
         contact,
         service_ca,
         fixed_zsk=None,
@@ -105,7 +104,6 @@ class aDNSConfig(dict):
             nsec3_hash_algorithm=nsec3_hash_algorithm,
             nsec3_hash_iterations=nsec3_hash_iterations,
             nsec3_salt_length=nsec3_salt_length,
-            parent_base_url=parent_base_url,
             contact=contact,
             service_ca=service_ca,
             fixed_zsk=fixed_zsk,
@@ -122,7 +120,6 @@ class aDNSConfig(dict):
         self.nsec3_hash_algorithm = nsec3_hash_algorithm
         self.nsec3_hash_iterations = nsec3_hash_iterations
         self.nsec3_salt_length = nsec3_salt_length
-        self.parent_base_url = parent_base_url
         self.service_ca = service_ca
         self.contact = contact
         self.fixed_zsk = fixed_zsk

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -305,7 +305,6 @@ def main():
         nsec3_hash_algorithm="SHA1",
         nsec3_hash_iterations=0,
         nsec3_salt_length=8,
-        parent_base_url=None,
         contact=["antdl@microsoft.com"],
         service_ca=service_ca_config,
     )


### PR DESCRIPTION
Removing delegation things
- endpoints
- related code
- unit testing
- changed existing logic a bit, probably didn't break too much (will see with more complete testing coming soon)

Removing certificate management leftovers
- crypto code
- KV tables

Overall, more unused includes and stuff removed as well.

Also, removed ACME subsystem together with HTTPClient, which were used to talk to parent zone.