### PR TITLE
More representative e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ logs
 node_modules
 env/
 scripts/env
+3rdparty/get-snp-report/bin/

--- a/3rdparty/get-snp-report/Makefile
+++ b/3rdparty/get-snp-report/Makefile
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+CFLAGS:=-O2 -Wall
+LDFLAGS:=-static -s # strip C binaries
+
+all: bin/get-snp-report bin/get-fake-snp-report bin/verbose-report bin/hex2report
+
+bin/hex2report: hex2report.o helpers.o
+	@mkdir -p bin
+	$(CC) $(LDFLAGS) -o $@ $^
+
+bin/get-fake-snp-report: get-fake-snp-report.o helpers.o
+	@mkdir -p bin
+	$(CC) $(LDFLAGS) -o $@ $^
+
+bin/get-snp-report: get-snp-report.o get-snp-report5.o get-snp-report6.o helpers.o
+	@mkdir -p bin
+	$(CC) $(LDFLAGS) -o $@ $^
+
+bin/verbose-report: verbose-report.o get-snp-report5.o get-snp-report6.o helpers.o
+	@mkdir -p bin
+	$(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+clean:
+	find -name '*.o' -print0 | xargs -0 -r rm
+	rm -rf bin out

--- a/3rdparty/get-snp-report/fetch5.h
+++ b/3rdparty/get-snp-report/fetch5.h
@@ -1,0 +1,9 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+bool fetchAttestationReport5(const char* report_data_hexstring, void **snp_report);
+
+// does /dev/sev exists. This is where the PSP is exposed in 5.15.*
+bool supportsDevSev();

--- a/3rdparty/get-snp-report/fetch6.h
+++ b/3rdparty/get-snp-report/fetch6.h
@@ -1,0 +1,10 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+bool fetchAttestationReport6(const char* report_data_hexstring, void **snp_report);
+
+// 6.1 linux exposees the PSP via /dev/sev-guest
+
+bool supportsDevSevGuest();

--- a/3rdparty/get-snp-report/get-fake-snp-report.c
+++ b/3rdparty/get-snp-report/get-fake-snp-report.c
@@ -1,0 +1,67 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "helpers.h"
+#include "snp-psp.h"
+
+bool fetchAttestationReport(char report_data_hexstring[], char host_data_hexstring[], void **snp_report)
+{
+ 
+    snp_attestation_report attestation_report;
+
+    uint8_t *default_report = decodeHexString("01000000010000001f00030000000000010000000000000000000000000000000200000000000000000000000000000000000000010000000000000000000028010000000000000000000000000000007ab000a323b3c873f5b81bbe584e7c1a26bcf40dc27e00f8e0d144b1ed2d14f10000000000000000000000000000000000000000000000000000000000000000e29af700e85b39996fa38226d2804b78cad746ffef4477360a61b47874bdecd640f9d32f5ff64a55baad3c545484d9ed28603a3ea835a83bd688b0ec1dcb36b6b8c22412e5b63115b75db8628b989bc598c475ca5f7683e8d351e7e789a1baff19041750567161ad52bf0d152bd76d7c6f313d0a0fd72d0089692c18f521155800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040aea62690b08eb6d680392c9a9b3db56a9b3cc44083b9da31fb88bcfc493407ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000028000000000000000000000000000000000000000000000000e6c86796cd44b0bc6b7c0d4fdab33e2807e14b5fc4538b3750921169d97bcf4447c7d3ab2a7c25f74c1641e2885c1011d025cc536f5c9a2504713136c7877f480000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003131c0f3e7be5c6e400f22404596e1874381e99d03de45ef8b97eee0a0fa93a4911550330343f14dddbbd6c0db83744f000000000000000000000000000000000000000000000000db07c83c5e6162c2387f3b76cd547672657f6a5df99df98efee7c15349320d83e086c5003ec43050a9b18d1c39dedc340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 0);
+    
+    memcpy((uint8_t*)&attestation_report, default_report, sizeof(snp_attestation_report));
+    memset(attestation_report.report_data, 0 , 64);
+    memset(attestation_report.host_data, 0 , 32);
+    
+    // MAA expects a SHA-256. So we use 32 bytes as size instead of msg_report_in.report_data
+    // the report data is passed as a hexstring which needs to be decoded into an array of 
+    // unsigned bytes
+
+    uint8_t *reportData = decodeHexString(report_data_hexstring, 64);     
+    memcpy(attestation_report.report_data, reportData , strlen(report_data_hexstring)/2);
+
+    uint8_t *hostData = decodeHexString(host_data_hexstring, 32);   
+    memcpy(attestation_report.host_data, hostData , strlen(host_data_hexstring)/2);
+
+    *snp_report = (snp_attestation_report *) malloc (sizeof(snp_attestation_report));        
+    memcpy(*snp_report, &attestation_report, sizeof(snp_attestation_report));
+
+    return true;
+}
+
+// Main expects the hex string representation of the report data as the only argument
+// Prints the raw binary format of the report so it can be consumed by the tools under
+// the directory internal/guest/attestation
+int main(int argc, char *argv[])
+{    
+    bool success;
+    uint8_t *snp_report_hex;
+
+    if (argc > 1) {        
+        success = fetchAttestationReport(argv[1], argv[2], (void*) &snp_report_hex);    
+    } else {        
+        success = fetchAttestationReport("", "", (void*) &snp_report_hex);    
+    }
+   
+    if (success == true) {
+        for (size_t i = 0; i < sizeof(snp_attestation_report); i++) {
+            fprintf(stdout, "%02x", (uint8_t) snp_report_hex[i]);            
+        }
+
+        return 0;
+    }
+
+    return -1;
+}

--- a/3rdparty/get-snp-report/get-snp-report.c
+++ b/3rdparty/get-snp-report/get-snp-report.c
@@ -1,0 +1,51 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "snp-attestation.h"
+#include "fetch5.h"
+#include "fetch6.h"
+
+
+
+// Main expects the hex string representation of the report data as the only argument
+// Prints the raw binary format of the report so it can be consumed by the tools under
+// the directory internal/guest/attestation
+int main(int argc, char *argv[])
+{
+    bool success = false;
+    uint8_t *snp_report_hex;
+    const char *report_data_hexstring = "";
+
+    if (argc > 1) {
+        report_data_hexstring = argv[1];
+    }
+
+    if (supportsDevSev()) {
+        success = fetchAttestationReport5(report_data_hexstring, (void*) &snp_report_hex);
+    } else if (supportsDevSevGuest()) {
+        success = fetchAttestationReport6(report_data_hexstring, (void*) &snp_report_hex);
+    } else {
+        fprintf(stderr, "No supported SNP device found\n");
+    }
+
+    if (success) {
+        for (size_t i = 0; i < sizeof(snp_attestation_report); i++) {
+            fprintf(stdout, "%02x", (uint8_t) snp_report_hex[i]);
+        }
+        fprintf(stdout, "\n");
+
+        return 0;
+    }
+
+    return -1;
+}

--- a/3rdparty/get-snp-report/get-snp-report5.c
+++ b/3rdparty/get-snp-report/get-snp-report5.c
@@ -1,0 +1,88 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "snp-attestation.h"
+#include "snp-ioctl5.h"
+
+#include "helpers.h"
+
+bool supportsDevSev()
+{
+    return access("/dev/sev", W_OK) == 0;
+}
+
+bool fetchAttestationReport5(const char* report_data_hexstring, void **snp_report)
+{
+    msg_report_req msg_report_in;    
+    msg_response_resp msg_report_out;
+    
+    int fd, rc;
+    
+    struct sev_snp_guest_request payload = {
+        .req_msg_type = SNP_MSG_REPORT_REQ,
+        .rsp_msg_type = SNP_MSG_REPORT_RSP,
+        .msg_version = 1,        
+        .request_len = sizeof(msg_report_in),
+        .request_uaddr = (uint64_t) (void*) &msg_report_in,
+        .response_len = sizeof(msg_report_out),
+        .response_uaddr = (uint64_t) (void*) &msg_report_out,
+        .error = 0
+    };
+    
+    memset((void*) &msg_report_in, 0, sizeof(msg_report_in));        
+    memset((void*) &msg_report_out, 0, sizeof(msg_report_out));
+
+    // the report data is passed as a hexstring which needs to be decoded into an array of 
+    // unsigned bytes
+    // MAA expects a SHA-256. So we use left align the bytes in the report data
+    
+    uint8_t *reportData = decodeHexString(report_data_hexstring, sizeof(msg_report_in.report_data));   
+    memcpy(msg_report_in.report_data, reportData, sizeof(msg_report_in.report_data));
+
+    // open the file descriptor of the PSP
+    fd = open("/dev/sev", O_RDWR | O_CLOEXEC);
+
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open /dev/sev\n");        
+        return false;
+    }
+
+    // issue the custom SEV_SNP_GUEST_MSG_REPORT sys call to the sev driver
+    rc = ioctl(fd, SEV_SNP_GUEST_MSG_REPORT, &payload);
+
+    if (rc < 0) {
+        fprintf(stderr, "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT\n");        
+        return false;    
+    }
+
+    #ifdef DEBUG_OUTPUT   
+    fprintf(stderr, "Response header:\n");
+    uint8_t *hdr = (uint8_t*) &msg_report_out;
+    
+    for (size_t i = 0; i < 32; i++) {
+        fprintf(stderr, "%02x", hdr[i]);
+        if (i % 16 == 15)
+            fprintf(stderr, "\n");
+        else
+            fprintf(stderr, " ");
+    }
+    fprintf(stderr, "Attestation report:\n");
+    printReport(&msg_report_out.report);
+    #endif
+
+    *snp_report = (snp_attestation_report *) malloc (sizeof(snp_attestation_report));        
+    memcpy(*snp_report, &msg_report_out.report, sizeof(snp_attestation_report));
+
+    return true;
+}

--- a/3rdparty/get-snp-report/get-snp-report6.c
+++ b/3rdparty/get-snp-report/get-snp-report6.c
@@ -1,0 +1,73 @@
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <memory.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "snp-attestation.h"
+#include "snp-ioctl6.h"
+#include "helpers.h"
+
+bool supportsDevSevGuest()
+{
+    return access("/dev/sev-guest", W_OK) == 0;
+}
+
+bool fetchAttestationReport6(const char* report_data_hexstring, void **snp_report)
+{
+    int fd;
+    int rc;
+
+    fd = open("/dev/sev-guest", O_RDWR | O_CLOEXEC);
+
+    if (fd < 0) {
+        fprintf(stdout, "Failed to open /dev/sev-guest\n");        
+        return false;
+    }
+
+    // this is the request, mostly the report data, vmpl
+    snp_report_req snp_request;
+    // and the result from the ioctl, in the get report case this will be the report
+    snp_report_resp snp_response;
+    
+    // the object we pass to the ioctl that wraps the psp request.
+    snp_guest_request_ioctl ioctl_request;
+
+    memset(&snp_request, 0, sizeof(snp_request));
+    
+    // the report data is passed as a hexstring which needs to be decoded into an array of 
+    // unsigned bytes
+    // MAA expects a SHA-256. So we use left align the bytes in the report data.
+
+    uint8_t *reportData = decodeHexString(report_data_hexstring, sizeof(snp_request.report_data));   
+    memcpy(snp_request.report_data, reportData, sizeof(snp_request.report_data));
+
+    memset(&snp_response, 0, sizeof(snp_response));
+    memset(&ioctl_request, 0, sizeof(ioctl_request));
+    
+    ioctl_request.msg_version = 1;
+    ioctl_request.req_data = (uint64_t)&snp_request;
+    ioctl_request.resp_data = (uint64_t)&snp_response;
+
+    rc = ioctl(fd, SNP_GET_REPORT, &ioctl_request);
+
+    if (rc < 0) {
+        fprintf(stderr, "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT\n");        
+        return false;  
+    }
+    
+    msg_response_resp *response = (msg_response_resp *)&snp_response.data;
+    snp_attestation_report *report = &response->report;
+
+
+    *snp_report = (snp_attestation_report *) malloc (sizeof(snp_attestation_report));        
+    memcpy(*snp_report, report, sizeof(snp_attestation_report));
+
+    return true;
+}

--- a/3rdparty/get-snp-report/helpers.c
+++ b/3rdparty/get-snp-report/helpers.c
@@ -1,0 +1,111 @@
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "snp-ioctl5.h"
+
+#include "helpers.h"
+
+
+
+// Helper functions
+uint8_t* decodeHexString(const char *hexstring, size_t padTo) // will zero pad to bufferLen
+{
+    size_t len = strlen(hexstring);
+    size_t out_len = len/2+1;
+    if (out_len < padTo)
+        out_len = padTo;
+    uint8_t *byte_array = (uint8_t*) malloc(out_len);
+    memset(byte_array, 0, out_len);
+
+    for (size_t i = 0; i < len; i+=2) {
+        sscanf(hexstring, "%2hhx", &byte_array[i/2]);
+        hexstring += 2;
+    }
+
+    return byte_array;
+}
+
+char* encodeHexToString(uint8_t byte_array[], size_t len)
+{
+    char* hexstring = (char*) malloc((2*len+1)*sizeof(char));
+
+    for (size_t i = 0; i < len; i++)
+        sprintf(&hexstring[i*2], "%02x", byte_array[i]);
+
+    hexstring[2*len] = '\0'; // string padding character
+    return hexstring;
+}
+
+void printBytes(const char *desc, const uint8_t *data, size_t len, bool swap)
+{
+    fprintf(stdout, "  %s: ", desc);
+    /* Pad it so that we have 24 characters before the hex */
+    int padding = 20 - strlen(desc);
+    if (padding < 0)
+        padding = 0;
+    for (int count = 0; count < padding; count++)
+        putchar(' ');
+
+    for (size_t pos = 0; pos < len; pos++) {
+        fprintf(stdout, "%02x", data[swap ? len - pos - 1 : pos]);
+        if (pos % 32 == 31 && pos != len - 1)
+            printf("\n                        ");
+        else if (pos % 16 == 15 && pos != len - 1)
+            putchar(' ');
+    }
+    fprintf(stdout, "\n");
+}
+
+void printReport(const snp_attestation_report *r)
+{
+    /*
+     * PRINT_VAL is intended to interpert the number in little endian and print
+     * the hex representation of it.  This should be used for bitfields as well
+     * as the spec orders the bits from most significant to least significant in
+     * the presented table (and when it says, for example, bits 63:6 are
+     * reserved, it means that val>>6 == 0).
+     */
+    PRINT_VAL(r, version);
+    PRINT_VAL(r, guest_svn);
+    PRINT_VAL(r, policy);
+    PRINT_VAL(r, family_id);
+    PRINT_VAL(r, image_id);
+    PRINT_VAL(r, vmpl);
+    PRINT_VAL(r, signature_algo);
+    PRINT_VAL(r, current_tcb);
+    PRINT_VAL(r, platform_info);
+    PRINT_VAL(r, author_key_en);
+    PRINT_BYTES(r, reserved1);
+    PRINT_BYTES(r, report_data);
+    PRINT_BYTES(r, measurement);
+    PRINT_BYTES(r, host_data);
+    PRINT_BYTES(r, id_key_digest);
+    PRINT_BYTES(r, author_key_digest);
+    PRINT_BYTES(r, report_id);
+    PRINT_BYTES(r, report_id_ma);
+    PRINT_VAL(r, reported_tcb);
+    PRINT_VAL(r, cpuid_fam_id);
+    PRINT_VAL(r, cpuid_mod_id);
+    PRINT_VAL(r, cpuid_step);
+    PRINT_BYTES(r, reserved2);
+    PRINT_BYTES(r, chip_id);
+    PRINT_VAL(r, committed_tcb);
+    PRINT_VAL(r, current_build);
+    PRINT_VAL(r, current_minor);
+    PRINT_VAL(r, current_major);
+    PRINT_BYTES(r, reserved3);
+    PRINT_VAL(r, committed_build);
+    PRINT_VAL(r, committed_minor);
+    PRINT_VAL(r, committed_major);
+    PRINT_BYTES(r, reserved4);
+    PRINT_VAL(r, launch_tcb);
+    PRINT_BYTES(r, reserved5);
+    PRINT_BYTES(r, signature);
+}

--- a/3rdparty/get-snp-report/helpers.h
+++ b/3rdparty/get-snp-report/helpers.h
@@ -1,0 +1,29 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "snp-attestation.h"
+
+
+#define PRINT_VAL(ptr, field) printBytes(#field, (const uint8_t *)&(ptr->field), sizeof(ptr->field), true)
+#define PRINT_BYTES(ptr, field) printBytes(#field, (const uint8_t *)&(ptr->field), sizeof(ptr->field), false)
+
+// Helper functions
+uint8_t* decodeHexString(const char *hexstring, size_t padTo);
+
+char* encodeHexToString(uint8_t byte_array[], size_t len);
+
+void printBytes(const char *desc, const uint8_t *data, size_t len, bool swap);
+
+void printReport(const snp_attestation_report *r);

--- a/3rdparty/get-snp-report/hex2report.c
+++ b/3rdparty/get-snp-report/hex2report.c
@@ -1,0 +1,38 @@
+
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "helpers.h"
+
+
+
+int main(int argc, char** argv)
+{
+    char buffer[102400];
+    int bytes_read = fread(buffer, 1, sizeof(buffer)-1, stdin);
+    if (bytes_read < 0) {
+        fprintf(stderr, "pipe read failed\n");
+        exit(-1);
+    }
+    if (bytes_read == 0) {
+        fprintf(stderr, "empty pipe\n");
+        exit(-1);
+    }
+    if (bytes_read < sizeof(snp_attestation_report)) {
+        fprintf(stderr, "pipe too short\n");
+        exit(-1);
+    }
+    buffer[bytes_read] = 0;
+
+    uint8_t* byte_array = decodeHexString(buffer, 0);
+        
+    printReport((const snp_attestation_report *)byte_array);
+
+    return 0;
+}

--- a/3rdparty/get-snp-report/snp-attestation.h
+++ b/3rdparty/get-snp-report/snp-attestation.h
@@ -1,0 +1,70 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include <sys/types.h>
+#include <stdint.h>
+
+/* structures common to both 5.15.* and 6.* kernels */
+/* essentially this is the interface to the PSP */
+
+/* from SEV-SNP Firmware ABI Specification Table 20 */
+typedef struct {
+    uint8_t report_data[64];
+    uint32_t vmpl;
+    uint8_t reserved[28]; // needs to be zero
+} msg_report_req;
+
+/* from SEV-SNP Firmware ABI Specification from Table 23 */
+
+// clang-format off
+typedef struct {
+    uint32_t    version;                // Version number of this attestation report. Set to 3 for the current (March 2025) specification.
+    uint32_t    guest_svn;              // The guest SVN
+    uint64_t    policy;                 // see table 10 - various settings
+    __uint128_t family_id;              // The family ID provided at launch.
+    __uint128_t image_id;               // The image ID provided at launch.
+    uint32_t    vmpl;                   // the request VMPL for the attestation report
+    uint32_t    signature_algo;         // The signature algorithm used to sign this report. See Chapter 10 for encodings.
+    uint8_t     current_tcb[8];         // CurrentTcb (was platform_version)
+    uint64_t    platform_info;          // information about the platform see table 24
+    uint32_t    author_key_en;          // The structure starting 48h
+                                        // Note: the order of C bitfields can't be relied on.  Hence this structure have to be an uint32_t.
+    uint32_t    reserved1;              // must be zero
+    uint8_t     report_data[64];        // Guest provided data.
+    uint8_t     measurement[48];        // measurement calculated at launch
+    uint8_t     host_data[32];          // data provided by the hypervisor at launch
+    uint8_t     id_key_digest[48];      // SHA-384 digest of the ID public key that signed the ID block provided in SNP_LAUNCH_FINISH
+    uint8_t     author_key_digest[48];  // SHA-384 digest of the Author public key that certified the ID key, if provided in SNP_LAUNCH_FINISH. Zeros if author_key_en is 1 (sounds backwards to me).
+    uint8_t     report_id[32];          // Report ID of this guest.
+    uint8_t     report_id_ma[32];       // Report ID of this guest's mmigration agent.
+    uint8_t     reported_tcb[8];        // Reported TCB version used to derive the VCEK that signed this report
+    uint8_t     cpuid_fam_id;           // Family ID (Combined Extended Family ID and Family ID)
+    uint8_t     cpuid_mod_id;           // Model (combined Extended Model and Model fields)
+    uint8_t     cpuid_step;             // Stepping
+    uint8_t     reserved2[21];          // reserved
+    uint8_t     chip_id[64];            // Identifier unique to the chip
+    uint8_t     committed_tcb[8];       // CommittedTcb (was committed_svn)
+    uint8_t     current_build;          // The build number of CurrentVersion.
+    uint8_t     current_minor;          // The minor number of CurrentVersion.
+    uint8_t     current_major;          // The major number of CurrentVersion.
+    uint8_t     reserved3;              // reserved
+    uint8_t     committed_build;        // The build number of CommittedVersion.
+    uint8_t     committed_minor;        // The minor number of CommittedVersion.
+    uint8_t     committed_major;        // The major number of CommittedVersion.
+    uint8_t     reserved4;              // reserved
+    uint8_t     launch_tcb[8];          // The CurrentTcb at the time the guest was launched or imported. (was launch_svn)
+    uint8_t     reserved5[168];         // reserved
+    uint8_t     signature[512];         // Signature of this attestation report. See table 23.
+} snp_attestation_report;
+// clang-format on
+
+/* from SEV-SNP Firmware ABI Specification Table 22 */
+typedef struct {
+    uint32_t status;
+    uint32_t report_size;
+    uint8_t reserved[24];
+    snp_attestation_report report;
+    uint8_t padding[64]; // padding to the size of SEV_SNP_REPORT_RSP_BUF_SZ (i.e., 1280 bytes)
+} msg_response_resp;

--- a/3rdparty/get-snp-report/snp-ioctl5.h
+++ b/3rdparty/get-snp-report/snp-ioctl5.h
@@ -1,0 +1,47 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+/* linux kernel 5.15.* versions of the ioctls that talk to the PSP */
+
+/* From sev-snp driver include/uapi/linux/psp-sev-guest.h */
+struct sev_snp_guest_request {
+    uint8_t req_msg_type;
+    uint8_t rsp_msg_type;
+    uint8_t msg_version;
+    uint16_t request_len;
+    uint64_t request_uaddr;
+    uint16_t response_len;
+    uint64_t response_uaddr;
+    uint32_t error;    /* firmware error code on failure (see psp-sev.h) */
+};
+
+enum snp_msg_type {
+    SNP_MSG_TYPE_INVALID = 0,
+    SNP_MSG_CPUID_REQ,
+    SNP_MSG_CPUID_RSP,
+    SNP_MSG_KEY_REQ,
+    SNP_MSG_KEY_RSP,
+    SNP_MSG_REPORT_REQ,
+    SNP_MSG_REPORT_RSP,
+    SNP_MSG_EXPORT_REQ,
+    SNP_MSG_EXPORT_RSP,
+    SNP_MSG_IMPORT_REQ,
+    SNP_MSG_IMPORT_RSP,
+    SNP_MSG_ABSORB_REQ,
+    SNP_MSG_ABSORB_RSP,
+    SNP_MSG_VMRK_REQ,
+    SNP_MSG_VMRK_RSP,
+    SNP_MSG_TYPE_MAX
+};
+
+
+#define SEV_GUEST_IOC_TYPE            'S'
+#define SEV_SNP_GUEST_MSG_REQUEST     _IOWR(SEV_GUEST_IOC_TYPE, 0x0, struct sev_snp_guest_request)
+#define SEV_SNP_GUEST_MSG_REPORT      _IOWR(SEV_GUEST_IOC_TYPE, 0x1, struct sev_snp_guest_request)
+#define SEV_SNP_GUEST_MSG_KEY         _IOWR(SEV_GUEST_IOC_TYPE, 0x2, struct sev_snp_guest_request)

--- a/3rdparty/get-snp-report/snp-ioctl6.h
+++ b/3rdparty/get-snp-report/snp-ioctl6.h
@@ -1,0 +1,75 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+/* linux kernel 6.* versions of the ioctls that talk to the PSP */
+
+/* From sev-snp driver include/uapi/linux/psp-sev-guest.h */
+
+struct sev_snp_guest_request {
+    uint8_t req_msg_type;
+    uint8_t rsp_msg_type;
+    uint8_t msg_version;
+    uint16_t request_len;
+    uint64_t request_uaddr;
+    uint16_t response_len;
+    uint64_t response_uaddr;
+    uint32_t error;            /* firmware error code on failure (see psp-sev.h) */
+};
+
+// aka/replaced by this from include/uapi/linux/sev-guest.h
+//
+typedef struct {
+    /* message version number (must be non-zero) */
+    uint8_t msg_version;
+
+    /* Request and response structure address */
+    uint64_t req_data;
+    uint64_t resp_data;
+
+    /* firmware error code on failure (see psp-sev.h) */
+    uint64_t fw_err;
+} snp_guest_request_ioctl;
+
+enum snp_msg_type {
+    SNP_MSG_TYPE_INVALID = 0,
+    SNP_MSG_CPUID_REQ,
+    SNP_MSG_CPUID_RSP,
+    SNP_MSG_KEY_REQ,
+    SNP_MSG_KEY_RSP,
+    SNP_MSG_REPORT_REQ,
+    SNP_MSG_REPORT_RSP,
+    SNP_MSG_EXPORT_REQ,
+    SNP_MSG_EXPORT_RSP,
+    SNP_MSG_IMPORT_REQ,
+    SNP_MSG_IMPORT_RSP,
+    SNP_MSG_ABSORB_REQ,
+    SNP_MSG_ABSORB_RSP,
+    SNP_MSG_VMRK_REQ,
+    SNP_MSG_VMRK_RSP,
+    SNP_MSG_TYPE_MAX
+};
+
+#define SNP_GUEST_REQ_IOC_TYPE        'S'
+#define SNP_GET_REPORT                _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x0, snp_guest_request_ioctl)
+#define SNP_GET_DERIVED_KEY           _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x1, snp_guest_request_ioctl)
+#define SNP_GET_EXT_REPORT            _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x2, snp_guest_request_ioctl)
+
+/* from SEV-SNP Firmware ABI Specification Table 20 */
+
+typedef struct {
+    uint8_t report_data[64];
+    uint32_t vmpl;
+    uint8_t reserved[28]; // needs to be zero
+} snp_report_req; // aka snp_report_req in (linux) include/uapi/linux/sev-guest.h
+
+typedef struct {
+/* response data, see SEV-SNP spec for the format */
+    uint8_t  data[4000];
+} snp_report_resp;

--- a/3rdparty/get-snp-report/snp-psp.h
+++ b/3rdparty/get-snp-report/snp-psp.h
@@ -1,0 +1,45 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#pragma once
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <stdint.h>
+
+/* From sev-snp driver include/uapi/linux/psp-sev-guest.h */
+struct sev_snp_guest_request {
+    uint8_t req_msg_type;
+    uint8_t rsp_msg_type;
+    uint8_t msg_version;
+    uint16_t request_len;
+    uint64_t request_uaddr;
+    uint16_t response_len;
+    uint64_t response_uaddr;
+    uint32_t error;           /* firmware error code on failure (see psp-sev.h) */
+};
+
+enum snp_msg_type {
+    SNP_MSG_TYPE_INVALID = 0,
+    SNP_MSG_CPUID_REQ,
+    SNP_MSG_CPUID_RSP,
+    SNP_MSG_KEY_REQ,
+    SNP_MSG_KEY_RSP,
+    SNP_MSG_REPORT_REQ,
+    SNP_MSG_REPORT_RSP,
+    SNP_MSG_EXPORT_REQ,
+    SNP_MSG_EXPORT_RSP,
+    SNP_MSG_IMPORT_REQ,
+    SNP_MSG_IMPORT_RSP,
+    SNP_MSG_ABSORB_REQ,
+    SNP_MSG_ABSORB_RSP,
+    SNP_MSG_VMRK_REQ,
+    SNP_MSG_VMRK_RSP,
+    SNP_MSG_TYPE_MAX
+};
+
+
+#define SEV_GUEST_IOC_TYPE           'S'
+#define SEV_SNP_GUEST_MSG_REQUEST    _IOWR(SEV_GUEST_IOC_TYPE, 0x0, struct sev_snp_guest_request)
+#define SEV_SNP_GUEST_MSG_REPORT     _IOWR(SEV_GUEST_IOC_TYPE, 0x1, struct sev_snp_guest_request)
+#define SEV_SNP_GUEST_MSG_KEY        _IOWR(SEV_GUEST_IOC_TYPE, 0x2, struct sev_snp_guest_request)

--- a/3rdparty/get-snp-report/verbose-report.c
+++ b/3rdparty/get-snp-report/verbose-report.c
@@ -1,0 +1,47 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT License. */
+
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "snp-attestation.h"
+#include "fetch5.h"
+#include "fetch6.h"
+
+#include "helpers.h"
+
+// Main expects the hex string representation of the report data as the only argument
+// Prints the raw binary format of the report so it can be consumed by the tools under
+// the directory internal/guest/attestation
+
+int main(int argc, char *argv[])
+{    
+    bool success = false;
+    uint8_t *snp_report_hex;
+    const char *report_data_hexstring = "";
+
+    if (argc > 1) {
+        report_data_hexstring = argv[1];
+    }
+
+    if (supportsDevSev()) {
+        success = fetchAttestationReport5(report_data_hexstring, (void*) &snp_report_hex);
+    } else if (supportsDevSevGuest()) {
+        success = fetchAttestationReport6(report_data_hexstring, (void*) &snp_report_hex);
+    } else {
+        fprintf(stderr, "No supported SNP device found\n");
+    }
+   
+    if (success) {
+        printReport((const snp_attestation_report *)snp_report_hex);
+        exit(0);
+    }
+    return 1;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set_property(
 
 if(COMPILE_TARGET STREQUAL "snp")
   execute_process(
-    COMMAND find / -type d -name "*security-context*"
+    COMMAND find / -maxdepth 1 -type d -name "security-context*"
     OUTPUT_VARIABLE SECURITY_CONTEXT_DIR
     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
   message(STATUS "UVM security context directory: ${SECURITY_CONTEXT_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,17 @@ enable_testing()
 
 set(TEST_PLATFORM_ARGS -t "${COMPILE_TARGET}")
 
+# For the e2e test to mock the attestation of the service being registered.
+if(COMPILE_TARGET STREQUAL "snp")
+  execute_process(
+    COMMAND "make"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/get-snp-report"
+    RESULT_VARIABLE RETURN_CODE)
+  if(NOT RETURN_CODE STREQUAL "0")
+    message(FATAL_ERROR "Error calling cat /etc/os-release")
+  endif()
+endif()
+
 add_test(
   NAME e2e_basic
   COMMAND python ../tests/e2e_basic.py -b "${CCF_PKG_DIR}/../bin" --library-dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ add_test(
   NAME e2e_basic
   COMMAND python ../tests/e2e_basic.py -b "${CCF_PKG_DIR}/../bin" --library-dir
           "${CMAKE_CURRENT_BINARY_DIR}" ${TEST_PLATFORM_ARGS})
+set_property(
+  TEST e2e_basic
+  APPEND
+  PROPERTY
+    ENVIRONMENT
+    "SNP_REPORT_BINARY=${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/get-snp-report/bin/get-snp-report"
+)
 
 if(COMPILE_TARGET STREQUAL "snp")
   execute_process(

--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -196,10 +196,4 @@ namespace ccfdns
 
   DECLARE_JSON_TYPE(Resign::In);
   DECLARE_JSON_REQUIRED_FIELDS(Resign::In, origin);
-
-  DECLARE_JSON_TYPE(GetAttestastion::In);
-  DECLARE_JSON_REQUIRED_FIELDS(GetAttestastion::In, report_data);
-
-  DECLARE_JSON_TYPE(GetAttestastion::Out);
-  DECLARE_JSON_REQUIRED_FIELDS(GetAttestastion::Out, quote);
 }

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -59,16 +59,4 @@ namespace ccfdns
     };
     using Out = void;
   };
-
-  struct GetAttestastion
-  {
-    struct In
-    {
-      std::vector<uint8_t> report_data;
-    };
-    struct Out
-    {
-      std::string quote;
-    };
-  };
 }

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -6,6 +6,8 @@ set -ex
 
 tdnf -y install zlib-devel  \
     clang-tools-extra  \
+    glibc-devel  \
+    glibc-static  \
     python3  \
     python-pip  \
     git  \


### PR DESCRIPTION
Mock 3rd party service attestation report outside test aDNS instance. Looks more convincing.

- [x] Integrate a [3rdparty](https://github.com/microsoft/confidential-sidecar-containers/tree/main/tools/get-snp-report ) attestation binary
- [x] Use that in e2e test instead of the `/internal/attestation` endpoint