### PR TITLE
Get and check uvm endorsements

### DIFF
--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1553,16 +1553,22 @@ namespace aDNS
       }
       catch (const nlohmann::json::parse_error& e)
       {
-        // If not, fallback to attempt as byte-encoded chain.
+        // If not, fallback to attempt as byte-encoded chain as is.
       }
 
       ccf::pal::PlatformAttestationMeasurement measurement = {};
       ccf::pal::PlatformAttestationReportData report_data = {};
+      ccf::pal::UVMEndorsements uvm_endorsements_descriptor = {};
       try
       {
         ccf::pal::verify_quote(attestation, measurement, report_data);
 
-        // TODO save verify_uvm_endorsements_descriptor if SNP
+        if (attestation.format != ccf::QuoteFormat::insecure_virtual)
+        {
+          uvm_endorsements_descriptor =
+            ccf::pal::verify_uvm_endorsements_descriptor(
+              attestation.uvm_endorsements.value(), measurement);
+        }
       }
       catch (const std::exception& e)
       {

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -81,9 +81,11 @@ def get_attestation(client, service_key, enclave_platform):
     if enclave_platform == "snp":
         attestation = get_snp_attestation(client, report_data)
         endorsements = get_container_group_snp_endorsements_base64()
+        uvm_endorsements = infra.snp.get_container_group_uvm_endorsements_base64()
     elif enclave_platform == "virtual":
         attestation = get_dummy_attestation(report_data)
         endorsements = ""
+        uvm_endorsements = ""
     else:
         raise ValueError(f"Unknown enclave platform: {enclave_platform}")
 
@@ -94,7 +96,7 @@ def get_attestation(client, service_key, enclave_platform):
         "format": attestation_format,
         "quote": attestation,
         "endorsements": endorsements,
-        "uvm_endorsements": "",
+        "uvm_endorsements": uvm_endorsements,
     }
     return json.dumps(dummy_attestation)
 

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -301,13 +301,15 @@ public:
     assert(!endorsements_path.empty());
     auto endorsements =
       slurp_file_string(endorsements_path + "/host-amd-cert-base64");
+    auto uvm_endorsements =
+      slurp_file_string(endorsements_path + "/reference-info-base64");
 
     nlohmann::json attestation;
     attestation["format"] = "AMD_SEV_SNP_v1";
     attestation["quote"] =
       ccf::crypto::b64_from_raw(snp_attestation->get_raw());
     attestation["endorsements"] = endorsements;
-    attestation["uvm_endorsements"] = "";
+    attestation["uvm_endorsements"] = uvm_endorsements;
     return attestation.dump();
   }
 


### PR DESCRIPTION
Fetch and pass uvm_endorsements to adns. Not being checked against policy yet, this's the next step.