### PR TITLE
Prove UVM checks against a simple rego policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ set(ENCLAVE_TARGET ccfdns.${COMPILE_TARGET})
 
 find_package(ZLIB)
 
+# Remove all INTERFACE_COMPILE_OPTIONS from regocpp::rego before linking. The
+# reason is that trieste has compilation flags we don't want exposed as
+# INTERFACE option (probably for no reason).
+set_target_properties(trieste PROPERTIES INTERFACE_COMPILE_OPTIONS "")
+
 add_ccf_app(
   ccfdns
   SRCS
@@ -73,6 +78,8 @@ add_ccf_app(
   ZLIB::ZLIB
   LINK_LIBS_SNP
   ZLIB::ZLIB)
+
+target_link_libraries(${ENCLAVE_TARGET} PRIVATE regocpp::rego)
 
 target_include_directories(
   ${ENCLAVE_TARGET}
@@ -155,7 +162,8 @@ endfunction()
 
 add_unit_test(resolver_tests ../tests/resolver_tests.cpp src/resolver.cpp
               src/rfc4034.cpp src/rfc5155.cpp src/base32.cpp)
-target_link_libraries(resolver_tests PRIVATE ZLIB::ZLIB ccf.${COMPILE_TARGET})
+target_link_libraries(resolver_tests PRIVATE ZLIB::ZLIB ccf.${COMPILE_TARGET}
+                                             regocpp::rego)
 target_include_directories(
   resolver_tests
   PRIVATE include

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -271,9 +271,6 @@ namespace aDNS
     virtual void set_service_registration_policy(
       const std::string& new_policy) = 0;
 
-    virtual bool evaluate_service_registration_policy(
-      const std::string& data) const = 0;
-
     virtual Configuration get_configuration() const = 0;
     virtual void set_configuration(const Configuration& cfg) = 0;
 

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -652,14 +652,6 @@ namespace ccfdns
       JSContext* ctx = nullptr;
     };
 
-    virtual bool evaluate_service_registration_policy(
-      const std::string& data) const override
-    {
-      RPJSRuntime rt;
-      std::string program = data + "\n\n" + service_registration_policy();
-      return rt.eval(program);
-    }
-
     using Resolver::register_service;
 
     virtual std::map<std::string, NodeInfo> get_node_information() override

--- a/tests/adns_service.py
+++ b/tests/adns_service.py
@@ -100,6 +100,22 @@ class aDNSConfig(dict):
         self.nsec3_salt_length = nsec3_salt_length
 
 
+DEFAULT_C_ACI_POLICY = """
+package policy
+
+default allow := false
+
+allow_svn if {
+    input.svn >= 101
+    input.svn != null
+}
+
+allow if {
+    allow_svn
+}
+"""
+
+
 def configure(base_url, cabundle, config, client_cert=None, num_retries=1):
     """Configure an aDNS service"""
 
@@ -233,6 +249,8 @@ def run(args, tcp_port=None, udp_port=None):
             library_dir=args.library_dir,
         )
         network.start_and_open(args)
+
+        set_policy(network, "set_registration_policy", DEFAULT_C_ACI_POLICY)
 
         args.adns.node_addresses = args.adns["node_addresses"] = assign_node_addresses(
             network, args.node_addresses, False

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -273,24 +273,27 @@ def test_service_reg(network, args):
         r = get_records(host, port, ca, service_name, "A", keys)
         print(r)
 
-        try:
-            set_policy(
-                network,
-                "set_registration_policy",
-                WRONG_SVN_POLICY,
-            )
+        if args.enclave_platform == "snp":
+            try:
+                set_policy(
+                    network,
+                    "set_registration_policy",
+                    WRONG_SVN_POLICY,
+                )
 
-            submit_service_registration(
-                client,
-                service_name,
-                "127.0.0.1",
-                port,
-                "tcp",
-                service_key,
-                args.enclave_platform,
-            )
-        except Exception as e:
-            assert "Failed to verify UVM endorsements" in str(e)
+                submit_service_registration(
+                    client,
+                    service_name,
+                    "127.0.0.1",
+                    port,
+                    "tcp",
+                    service_key,
+                    args.enclave_platform,
+                )
+            except Exception as e:
+                assert "Failed to verify UVM endorsements" in str(e)
+            else:
+                assert False, "Expected to fail"
 
 
 def run(args):

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -71,7 +71,10 @@ public:
   std::map<Name, ccf::crypto::Pem, RFC4034::CanonicalNameOrdering>
     zone_signing_keys;
 
-  std::string service_registration_policy_str;
+  std::string service_registration_policy_str = R"(
+package policy
+default allow := true
+)";
 
   Resolver::Configuration configuration;
 
@@ -232,12 +235,6 @@ public:
     const std::string& new_policy) override
   {
     service_registration_policy_str = new_policy;
-  }
-
-  virtual bool evaluate_service_registration_policy(
-    const std::string& data) const override
-  {
-    return true;
   }
 
   uint32_t get_fresh_time() override


### PR DESCRIPTION
Link against regocpp and verify uvm endorsements against sample policy during service registration.

An ultimate end-policy is not a goal of this PR, this aims to only prove rego policies can be verified and accepted (or rejected) based on the SVN number, for instance,

A proper set of policies is to be defined further.