### PR TITLE
Add platform relying party policies

### DIFF
--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -203,5 +203,5 @@ namespace ccfdns
 
   DECLARE_JSON_TYPE(SetPlatformRelyingPartyPolicy::In);
   DECLARE_JSON_REQUIRED_FIELDS(
-    SetPlatformRelyingPartyPolicy::In, service_name, policy, attestation);
+    SetPlatformRelyingPartyPolicy::In, platform, policy, attestation);
 }

--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -200,4 +200,8 @@ namespace ccfdns
   DECLARE_JSON_TYPE(SetServiceRelyingPartyPolicy::In);
   DECLARE_JSON_REQUIRED_FIELDS(
     SetServiceRelyingPartyPolicy::In, service_name, policy, attestation);
+
+  DECLARE_JSON_TYPE(SetPlatformRelyingPartyPolicy::In);
+  DECLARE_JSON_REQUIRED_FIELDS(
+    SetPlatformRelyingPartyPolicy::In, service_name, policy, attestation);
 }

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -75,7 +75,7 @@ namespace ccfdns
   {
     struct In
     {
-      std::string service_name;
+      aDNS::AttestationType platform;
       std::string policy;
       std::string attestation;
     };

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -70,4 +70,15 @@ namespace ccfdns
     };
     using Out = void;
   };
+
+  struct SetPlatformRelyingPartyPolicy
+  {
+    struct In
+    {
+      std::string service_name;
+      std::string policy;
+      std::string attestation;
+    };
+    using Out = void;
+  };
 }

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -266,26 +266,25 @@ namespace aDNS
 
     virtual void register_service(const RegistrationRequest& req);
 
-    virtual std::string service_relying_party_registration_policy() const = 0;
+    virtual std::string service_definition_auth() const = 0;
 
-    virtual void set_service_relying_party_registration_policy(
+    virtual void set_service_definition_auth(const std::string& new_policy) = 0;
+
+    virtual std::string platform_definition_auth() const = 0;
+
+    virtual void set_platform_definition_auth(
       const std::string& new_policy) = 0;
 
-    virtual std::string platform_relying_party_registration_policy() const = 0;
-
-    virtual void set_platform_relying_party_registration_policy(
-      const std::string& new_policy) = 0;
-
-    virtual std::string service_relying_party_policy(
+    virtual std::string service_definition(
       const std::string& service_name) const = 0;
 
-    virtual void set_service_relying_party_policy(
+    virtual void set_service_definition(
       const std::string& service_name, const std::string& new_policy) = 0;
 
-    virtual std::string platform_relying_party_policy(
+    virtual std::string platform_definition(
       const std::string& platform) const = 0;
 
-    virtual void set_platform_relying_party_policy(
+    virtual void set_platform_definition(
       const std::string& platform, const std::string& new_policy) = 0;
 
     virtual Configuration get_configuration() const = 0;

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -283,10 +283,10 @@ namespace aDNS
       const std::string& service_name, const std::string& new_policy) = 0;
 
     virtual std::string platform_relying_party_policy(
-      const std::string& service_name) const = 0;
+      const std::string& platform) const = 0;
 
     virtual void set_platform_relying_party_policy(
-      const std::string& service_name, const std::string& new_policy) = 0;
+      const std::string& platform, const std::string& new_policy) = 0;
 
     virtual Configuration get_configuration() const = 0;
     virtual void set_configuration(const Configuration& cfg) = 0;

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -266,15 +266,26 @@ namespace aDNS
 
     virtual void register_service(const RegistrationRequest& req);
 
-    virtual std::string service_registration_policy() const = 0;
+    virtual std::string service_relying_party_registration_policy() const = 0;
 
-    virtual void set_service_registration_policy(
+    virtual void set_service_relying_party_registration_policy(
+      const std::string& new_policy) = 0;
+
+    virtual std::string platform_relying_party_registration_policy() const = 0;
+
+    virtual void set_platform_relying_party_registration_policy(
       const std::string& new_policy) = 0;
 
     virtual std::string service_relying_party_policy(
       const std::string& service_name) const = 0;
 
     virtual void set_service_relying_party_policy(
+      const std::string& service_name, const std::string& new_policy) = 0;
+
+    virtual std::string platform_relying_party_policy(
+      const std::string& service_name) const = 0;
+
+    virtual void set_platform_relying_party_policy(
       const std::string& service_name, const std::string& new_policy) = 0;
 
     virtual Configuration get_configuration() const = 0;

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -218,22 +218,22 @@ namespace ccfdns
 
     using ServiceRelyingPartyRegistrationPolicy =
       ccf::ServiceValue<std::string>;
-    const std::string service_relying_party_registration_policy_table_name =
-      "public:ccf.gov.ccfdns.service_relying_party_registration_policy";
+    const std::string service_definition_auth_table_name =
+      "public:ccf.gov.ccfdns.service_definition_auth";
 
     using ServiceRelyingPartyPolicy = ccf::ServiceMap<std::string, std::string>;
-    const std::string service_relying_party_policy_table_name =
-      "public:ccf.gov.ccfdns.service_relying_party_policy";
+    const std::string service_definition_table_name =
+      "public:ccf.gov.ccfdns.service_definition";
 
     using PlatformRelyingPartyRegistrationPolicy =
       ccf::ServiceValue<std::string>;
-    const std::string platform_relying_party_registration_policy_table_name =
-      "public:ccf.gov.ccfdns.platform_relying_party_registration_policy";
+    const std::string platform_definition_auth_table_name =
+      "public:ccf.gov.ccfdns.platform_definition_auth";
 
     using PlatformRelyingPartyPolicy =
       ccf::ServiceMap<std::string, std::string>;
-    const std::string platform_relying_party_policy_table_name =
-      "public:ccf.gov.ccfdns.platform_relying_party_policy";
+    const std::string platform_definition_table_name =
+      "public:ccf.gov.ccfdns.platform_definition";
 
     using RegistrationRequests =
       ccf::ServiceMap<Name, RegisterServiceWithPreviousVersion>;
@@ -605,13 +605,12 @@ namespace ccfdns
       table->put(origin_lowered, *value);
     }
 
-    virtual std::string service_relying_party_registration_policy()
-      const override
+    virtual std::string service_definition_auth() const override
     {
       check_context();
 
       auto policy_table = rotx().ro<ServiceRelyingPartyRegistrationPolicy>(
-        service_relying_party_registration_policy_table_name);
+        service_definition_auth_table_name);
       const std::optional<std::string> policy = policy_table->get();
       if (!policy)
         throw std::runtime_error(
@@ -619,13 +618,13 @@ namespace ccfdns
       return *policy;
     }
 
-    virtual void set_service_relying_party_registration_policy(
+    virtual void set_service_definition_auth(
       const std::string& new_policy) override
     {
       check_context();
 
       auto policy = rwtx().rw<ServiceRelyingPartyRegistrationPolicy>(
-        service_relying_party_registration_policy_table_name);
+        service_definition_auth_table_name);
 
       if (!policy)
         throw std::runtime_error(
@@ -634,26 +633,26 @@ namespace ccfdns
       policy->put(new_policy);
     }
 
-    virtual std::string service_relying_party_policy(
+    virtual std::string service_definition(
       const std::string& service_name) const override
     {
       check_context();
 
-      auto policy_table = rotx().ro<ServiceRelyingPartyPolicy>(
-        service_relying_party_policy_table_name);
+      auto policy_table =
+        rotx().ro<ServiceRelyingPartyPolicy>(service_definition_table_name);
       const std::optional<std::string> policy = policy_table->get(service_name);
       if (!policy)
         throw std::runtime_error("no service relying party policy");
       return *policy;
     }
 
-    virtual void set_service_relying_party_policy(
+    virtual void set_service_definition(
       const std::string& service_name, const std::string& new_policy) override
     {
       check_context();
 
-      auto policy = rwtx().rw<ServiceRelyingPartyPolicy>(
-        service_relying_party_policy_table_name);
+      auto policy =
+        rwtx().rw<ServiceRelyingPartyPolicy>(service_definition_table_name);
 
       if (!policy)
         throw std::runtime_error(
@@ -662,13 +661,12 @@ namespace ccfdns
       policy->put(service_name, new_policy);
     }
 
-    virtual std::string platform_relying_party_registration_policy()
-      const override
+    virtual std::string platform_definition_auth() const override
     {
       check_context();
 
       auto policy_table = rotx().ro<PlatformRelyingPartyRegistrationPolicy>(
-        platform_relying_party_registration_policy_table_name);
+        platform_definition_auth_table_name);
       const std::optional<std::string> policy = policy_table->get();
       if (!policy)
         throw std::runtime_error(
@@ -676,13 +674,13 @@ namespace ccfdns
       return *policy;
     }
 
-    virtual void set_platform_relying_party_registration_policy(
+    virtual void set_platform_definition_auth(
       const std::string& new_policy) override
     {
       check_context();
 
       auto policy = rwtx().rw<PlatformRelyingPartyRegistrationPolicy>(
-        platform_relying_party_registration_policy_table_name);
+        platform_definition_auth_table_name);
 
       if (!policy)
         throw std::runtime_error(
@@ -691,26 +689,26 @@ namespace ccfdns
       policy->put(new_policy);
     }
 
-    virtual std::string platform_relying_party_policy(
+    virtual std::string platform_definition(
       const std::string& platform) const override
     {
       check_context();
 
-      auto policy_table = rotx().ro<PlatformRelyingPartyPolicy>(
-        platform_relying_party_policy_table_name);
+      auto policy_table =
+        rotx().ro<PlatformRelyingPartyPolicy>(platform_definition_table_name);
       const std::optional<std::string> policy = policy_table->get(platform);
       if (!policy)
         throw std::runtime_error("no platform relying party policy");
       return *policy;
     }
 
-    virtual void set_platform_relying_party_policy(
+    virtual void set_platform_definition(
       const std::string& platform, const std::string& new_policy) override
     {
       check_context();
 
-      auto policy = rwtx().rw<PlatformRelyingPartyPolicy>(
-        platform_relying_party_policy_table_name);
+      auto policy =
+        rwtx().rw<PlatformRelyingPartyPolicy>(platform_definition_table_name);
 
       if (!policy)
         throw std::runtime_error(
@@ -1831,8 +1829,7 @@ namespace ccfdns
           ctx.rpc_ctx->set_response_header(
             ccf::http::headers::CONTENT_TYPE,
             ccf::http::headervalues::contenttype::TEXT);
-          ctx.rpc_ctx->set_response_body(
-            ccfdns->service_relying_party_registration_policy());
+          ctx.rpc_ctx->set_response_body(ccfdns->service_definition_auth());
           ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
         }
         catch (std::exception& ex)
@@ -1876,9 +1873,7 @@ namespace ccfdns
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
-      auto set_service_relying_party_policy = [this](
-                                                auto& ctx,
-                                                nlohmann::json&& params) {
+      auto set_service_definition = [this](auto& ctx, nlohmann::json&& params) {
         try
         {
           ContextContext cc(ccfdns, ctx);
@@ -1896,11 +1891,10 @@ namespace ccfdns
           if (attestation.format != ccf::QuoteFormat::insecure_virtual)
           {
             verify_against_service_registration_policy(
-              ccfdns->service_relying_party_registration_policy(),
-              uvm_descriptor);
+              ccfdns->service_definition_auth(), uvm_descriptor);
           }
 
-          ccfdns->set_service_relying_party_policy(in.service_name, in.policy);
+          ccfdns->set_service_definition(in.service_name, in.policy);
 
           return ccf::make_success();
         }
@@ -1916,7 +1910,7 @@ namespace ccfdns
       make_endpoint(
         "/set-service-relying-party-policy",
         HTTP_POST,
-        ccf::json_adapter(set_service_relying_party_policy),
+        ccf::json_adapter(set_service_definition),
         ccf::no_auth_required)
         .set_auto_schema<
           SetServiceRelyingPartyPolicy::In,
@@ -1924,7 +1918,7 @@ namespace ccfdns
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
 
-      auto set_platform_relying_party_policy =
+      auto set_platform_definition =
         [this](auto& ctx, nlohmann::json&& params) {
           try
           {
@@ -1943,12 +1937,11 @@ namespace ccfdns
             if (attestation.format != ccf::QuoteFormat::insecure_virtual)
             {
               verify_against_platform_registration_policy(
-                ccfdns->platform_relying_party_registration_policy(),
-                uvm_descriptor);
+                ccfdns->platform_definition_auth(), uvm_descriptor);
             }
 
             auto platform = nlohmann::json(in.platform).dump();
-            ccfdns->set_platform_relying_party_policy(platform, in.policy);
+            ccfdns->set_platform_definition(platform, in.policy);
 
             return ccf::make_success();
           }
@@ -1964,7 +1957,7 @@ namespace ccfdns
       make_endpoint(
         "/set-platform-relying-party-policy",
         HTTP_POST,
-        ccf::json_adapter(set_platform_relying_party_policy),
+        ccf::json_adapter(set_platform_definition),
         ccf::no_auth_required)
         .set_auto_schema<
           SetPlatformRelyingPartyPolicy::In,

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -1944,7 +1944,7 @@ namespace ccfdns
           if (attestation.format != ccf::QuoteFormat::insecure_virtual)
           {
             verify_against_platform_registration_policy(
-              ccfdns->service_relying_party_registration_policy(),
+              ccfdns->platform_relying_party_registration_policy(),
               uvm_descriptor);
           }
 

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -668,7 +668,7 @@ namespace ccfdns
       check_context();
 
       auto policy_table = rotx().ro<PlatformRelyingPartyRegistrationPolicy>(
-        service_relying_party_registration_policy_table_name);
+        platform_relying_party_registration_policy_table_name);
       const std::optional<std::string> policy = policy_table->get();
       if (!policy)
         throw std::runtime_error(

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1615,13 +1615,14 @@ namespace aDNS
       {
         try
         {
+          auto platform = nlohmann::json(info.attestation_type).dump();
+          verify_platform_relying_party_policy(
+            ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
+            platform_relying_party_policy(platform));
+
           verify_service_relying_party_policy(
             ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
             service_relying_party_policy(service_name));
-
-          verify_platform_relying_party_policy(
-            ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
-            platform_relying_party_policy(service_name));
         }
         catch (const std::exception& e)
         {

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -65,6 +65,13 @@ namespace
         fmt::format("Error while applying policy: {}", qv));
     }
   }
+
+  void verify_platform_relying_party_policy(
+    const std::string& host_data, const std::string& policy)
+  {
+    // Currently reuse service relying party logic, because input is the same.
+    verify_service_relying_party_policy(host_data, policy);
+  }
 }
 
 namespace aDNS
@@ -1611,6 +1618,10 @@ namespace aDNS
           verify_service_relying_party_policy(
             ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
             service_relying_party_policy(service_name));
+
+          verify_platform_relying_party_policy(
+            ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
+            platform_relying_party_policy(service_name));
         }
         catch (const std::exception& e)
         {

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -32,7 +32,7 @@ using namespace RFC1035;
 
 namespace
 {
-  void verify_service_relying_party_policy(
+  void verify_service_definition(
     const std::string& host_data, const std::string& policy)
   {
     nlohmann::json rego_input;
@@ -66,11 +66,11 @@ namespace
     }
   }
 
-  void verify_platform_relying_party_policy(
+  void verify_platform_definition(
     const std::string& host_data, const std::string& policy)
   {
     // Currently reuse service relying party logic, because input is the same.
-    verify_service_relying_party_policy(host_data, policy);
+    verify_service_definition(host_data, policy);
   }
 }
 
@@ -1616,13 +1616,13 @@ namespace aDNS
         try
         {
           auto platform = nlohmann::json(info.attestation_type).dump();
-          verify_platform_relying_party_policy(
+          verify_platform_definition(
             ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
-            platform_relying_party_policy(platform));
+            platform_definition(platform));
 
-          verify_service_relying_party_policy(
+          verify_service_definition(
             ccf::crypto::b64_from_raw(host_data.h.data(), host_data.h.size()),
-            service_relying_party_policy(service_name));
+            service_definition(service_name));
         }
         catch (const std::exception& e)
         {

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -330,8 +330,15 @@ function updateServiceConfig(new_config) {
   }
 }
 
-function setRegistrationPolicy(new_policy) {
-  ccf.kv["public:ccf.gov.ccfdns.service_registration_policy"].set(
+function setServiceRelyingPartyRegistrationPolicy(new_policy) {
+  ccf.kv["public:ccf.gov.ccfdns.service_relying_party_registration_policy"].set(
+    getSingletonKvKey(),
+    ccf.jsonCompatibleToBuf(new_policy),
+  );
+}
+
+function setPlatformRelyingPartyRegistrationPolicy(new_policy) {
+  ccf.kv["public:ccf.gov.ccfdns.platform_relying_party_registration_policy"].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(new_policy),
   );
@@ -1376,13 +1383,24 @@ const actions = new Map([
     ),
   ],
   [
-    "set_registration_policy",
+    "set_service_relying_party_registration_policy",
     new Action(
       function (args) {
         checkType(args.new_policy, "string", "new_policy");
       },
       function (args) {
-        setRegistrationPolicy(args.new_policy);
+        setServiceRelyingPartyRegistrationPolicy(args.new_policy);
+      },
+    ),
+  ],
+  [
+    "set_platform_relying_party_registration_policy",
+    new Action(
+      function (args) {
+        checkType(args.new_policy, "string", "new_policy");
+      },
+      function (args) {
+        setPlatformRelyingPartyRegistrationPolicy(args.new_policy);
       },
     ),
   ],

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -331,16 +331,17 @@ function updateServiceConfig(new_config) {
 }
 
 function setServiceRelyingPartyRegistrationPolicy(new_policy) {
-  ccf.kv["public:ccf.gov.ccfdns.service_relying_party_registration_policy"].set(
+  ccf.kv["public:ccf.gov.ccfdns.service_definition_auth"].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(new_policy),
   );
 }
 
 function setPlatformRelyingPartyRegistrationPolicy(new_policy) {
-  ccf.kv[
-    "public:ccf.gov.ccfdns.platform_relying_party_registration_policy"
-  ].set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(new_policy));
+  ccf.kv["public:ccf.gov.ccfdns.platform_definition_auth"].set(
+    getSingletonKvKey(),
+    ccf.jsonCompatibleToBuf(new_policy),
+  );
 }
 
 const actions = new Map([
@@ -1382,7 +1383,7 @@ const actions = new Map([
     ),
   ],
   [
-    "set_service_relying_party_registration_policy",
+    "set_service_definition_auth",
     new Action(
       function (args) {
         checkType(args.new_policy, "string", "new_policy");
@@ -1393,7 +1394,7 @@ const actions = new Map([
     ),
   ],
   [
-    "set_platform_relying_party_registration_policy",
+    "set_platform_definition_auth",
     new Action(
       function (args) {
         checkType(args.new_policy, "string", "new_policy");

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -338,10 +338,9 @@ function setServiceRelyingPartyRegistrationPolicy(new_policy) {
 }
 
 function setPlatformRelyingPartyRegistrationPolicy(new_policy) {
-  ccf.kv["public:ccf.gov.ccfdns.platform_relying_party_registration_policy"].set(
-    getSingletonKvKey(),
-    ccf.jsonCompatibleToBuf(new_policy),
-  );
+  ccf.kv[
+    "public:ccf.gov.ccfdns.platform_relying_party_registration_policy"
+  ].set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(new_policy));
 }
 
 const actions = new Map([

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -37,6 +37,8 @@ package policy
 default allow := true
 """
 
+SEV_SNP_CONTAINERPLAT_AMD_UVM = "SEV-SNP:ContainerPlat-AMD-UVM"
+
 
 def get_container_group_snp_endorsements_base64():
     security_context_dir = infra.snp.get_security_context_dir()
@@ -454,7 +456,7 @@ def set_service_relying_party_policy(network, enclave, service_name, good=True):
         assert r.status_code == http.HTTPStatus.NO_CONTENT, r
 
 
-def set_platform_relying_party_policy(network, enclave, service_name, good=True):
+def set_platform_relying_party_policy(network, enclave, platform, good=True):
     policy = get_platform_relying_party_policy(enclave=enclave, good=good)
     primary, _ = network.find_primary()
 
@@ -465,7 +467,7 @@ def set_platform_relying_party_policy(network, enclave, service_name, good=True)
         r = client.post(
             "/app/set-platform-relying-party-policy",
             {
-                "service_name": service_name,
+                "platform": platform,
                 "policy": policy,
                 "attestation": get_attestation(
                     report_data=report_data, enclave=enclave
@@ -525,7 +527,7 @@ def test_service_registration(network, args):
         network, enclave, service_name="test.acidns10.attested.name.", good=True
     )
     set_platform_relying_party_policy_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", good=True
+        network, enclave, platform=SEV_SNP_CONTAINERPLAT_AMD_UVM, good=True
     )
 
     register_successfully(
@@ -552,7 +554,7 @@ def test_service_registration(network, args):
         network, enclave, service_name="test.acidns10.attested.name.", good=False
     )
     set_platform_relying_party_policy_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", good=True
+        network, enclave, platform=SEV_SNP_CONTAINERPLAT_AMD_UVM, good=True
     )
     register_failed(
         "Policy not satisfied",
@@ -567,7 +569,7 @@ def test_service_registration(network, args):
         network, enclave, service_name="test.acidns10.attested.name.", good=True
     )
     set_platform_relying_party_policy_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", good=False
+        network, enclave, platform=SEV_SNP_CONTAINERPLAT_AMD_UVM, good=False
     )
     register_failed(
         "Policy not satisfied",
@@ -608,7 +610,7 @@ def test_policy_registration(network, args):
     set_platform_relying_party_policy_successfully(
         network,
         enclave=args.enclave_platform,
-        service_name="test.acidns10.attested.name.",
+        platform=SEV_SNP_CONTAINERPLAT_AMD_UVM,
     )
 
     set_platform_relying_party_registration_policy(
@@ -618,7 +620,7 @@ def test_policy_registration(network, args):
         "Policy not satisfied",
         network,
         enclave=args.enclave_platform,
-        service_name="test.acidns10.attested.name.",
+        platform=SEV_SNP_CONTAINERPLAT_AMD_UVM,
     )
 
 

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -368,8 +368,8 @@ allow if {{
 """
 
 
-def set_service_registration_policy(network, policy):
-    set_policy(network, "set_registration_policy", policy)
+def set_service_relying_party_registration_policy(network, policy):
+    set_policy(network, "set_service_relying_party_registration_policy", policy)
 
 
 def set_service_relying_party_policy(network, enclave, service_name, good=True):
@@ -416,7 +416,7 @@ def test_service_registration(network, args):
     enclave = args.enclave_platform
     service_key = ec.generate_private_key(ec.SECP384R1(), default_backend())
 
-    set_service_registration_policy(network, SERVICE_REGISTRATION_ALLOW_ALL)
+    set_service_relying_party_registration_policy(network, SERVICE_REGISTRATION_ALLOW_ALL)
     set_relying_party_policy_successfully(
         network, enclave, service_name="test.acidns10.attested.name.", good=True
     )
@@ -454,7 +454,7 @@ def test_service_registration(network, args):
 
 def test_policy_registration(network, args):
     # Test with a proper service registration policy which checks UVM endorsements.
-    set_service_registration_policy(
+    set_service_relying_party_registration_policy(
         network, create_service_registration_policy(network, good=True)
     )
     set_relying_party_policy_successfully(
@@ -464,7 +464,7 @@ def test_policy_registration(network, args):
     )
 
     # Test with incremented SVN to ensure current UVM endorsements are not accepted when setting new relying party policy.
-    set_service_registration_policy(
+    set_service_relying_party_registration_policy(
         network, create_service_registration_policy(network, good=False)
     )
     set_relying_party_policy_failed(

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -416,7 +416,9 @@ def test_service_registration(network, args):
     enclave = args.enclave_platform
     service_key = ec.generate_private_key(ec.SECP384R1(), default_backend())
 
-    set_service_relying_party_registration_policy(network, SERVICE_REGISTRATION_ALLOW_ALL)
+    set_service_relying_party_registration_policy(
+        network, SERVICE_REGISTRATION_ALLOW_ALL
+    )
     set_relying_party_policy_successfully(
         network, enclave, service_name="test.acidns10.attested.name.", good=True
     )

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -76,19 +76,19 @@ public:
   std::map<Name, ccf::crypto::Pem, RFC4034::CanonicalNameOrdering>
     zone_signing_keys;
 
-  std::string service_relying_party_registration_policy_str = R"(
+  std::string service_definition_auth_str = R"(
 package policy
 default allow := true
 )";
 
-  std::string platform_relying_party_registration_policy_str = R"(
+  std::string platform_definition_auth_str = R"(
 package policy
 default allow := true
 )";
 
-  std::map<std::string, std::string> service_relying_party_policy_str;
+  std::map<std::string, std::string> service_definition_str;
 
-  std::map<std::string, std::string> platform_relying_party_policy_str;
+  std::map<std::string, std::string> platform_definition_str;
 
   Resolver::Configuration configuration;
 
@@ -240,61 +240,60 @@ default allow := true
       CCF_APP_DEBUG("<empty>");
   }
 
-  virtual std::string service_relying_party_registration_policy() const override
+  virtual std::string service_definition_auth() const override
   {
-    return service_relying_party_registration_policy_str;
+    return service_definition_auth_str;
   }
 
-  virtual void set_service_relying_party_registration_policy(
+  virtual void set_service_definition_auth(
     const std::string& new_policy) override
   {
-    service_relying_party_registration_policy_str = new_policy;
+    service_definition_auth_str = new_policy;
   }
 
-  virtual std::string platform_relying_party_registration_policy()
-    const override
+  virtual std::string platform_definition_auth() const override
   {
-    return platform_relying_party_registration_policy_str;
+    return platform_definition_auth_str;
   }
 
-  virtual void set_platform_relying_party_registration_policy(
+  virtual void set_platform_definition_auth(
     const std::string& new_policy) override
   {
-    platform_relying_party_registration_policy_str = new_policy;
+    platform_definition_auth_str = new_policy;
   }
 
-  virtual std::string service_relying_party_policy(
+  virtual std::string service_definition(
     const std::string& service_name) const override
   {
-    auto it = service_relying_party_policy_str.find(service_name);
-    if (it != service_relying_party_policy_str.end())
+    auto it = service_definition_str.find(service_name);
+    if (it != service_definition_str.end())
     {
       return it->second;
     }
     return DEFAULT_PERMISSIVE_RELYING_PARTY_POLICY;
   }
 
-  virtual void set_service_relying_party_policy(
+  virtual void set_service_definition(
     const std::string& service_name, const std::string& new_policy) override
   {
-    service_relying_party_policy_str[service_name] = new_policy;
+    service_definition_str[service_name] = new_policy;
   }
 
-  virtual std::string platform_relying_party_policy(
+  virtual std::string platform_definition(
     const std::string& platform) const override
   {
-    auto it = platform_relying_party_policy_str.find(platform);
-    if (it != platform_relying_party_policy_str.end())
+    auto it = platform_definition_str.find(platform);
+    if (it != platform_definition_str.end())
     {
       return it->second;
     }
     return DEFAULT_PERMISSIVE_RELYING_PARTY_POLICY;
   }
 
-  virtual void set_platform_relying_party_policy(
+  virtual void set_platform_definition(
     const std::string& platform, const std::string& new_policy) override
   {
-    platform_relying_party_policy_str[platform] = new_policy;
+    platform_definition_str[platform] = new_policy;
   }
 
   uint32_t get_fresh_time() override

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -76,12 +76,19 @@ public:
   std::map<Name, ccf::crypto::Pem, RFC4034::CanonicalNameOrdering>
     zone_signing_keys;
 
-  std::string service_registration_policy_str = R"(
+  std::string service_relying_party_registration_policy_str = R"(
+package policy
+default allow := true
+)";
+
+  std::string platform_relying_party_registration_policy_str = R"(
 package policy
 default allow := true
 )";
 
   std::map<std::string, std::string> service_relying_party_policy_str;
+
+  std::map<std::string, std::string> platform_relying_party_policy_str;
 
   Resolver::Configuration configuration;
 
@@ -233,15 +240,27 @@ default allow := true
       CCF_APP_DEBUG("<empty>");
   }
 
-  virtual std::string service_registration_policy() const override
+  virtual std::string service_relying_party_registration_policy() const override
   {
-    return service_registration_policy_str;
+    return service_relying_party_registration_policy_str;
   }
 
-  virtual void set_service_registration_policy(
+  virtual void set_service_relying_party_registration_policy(
     const std::string& new_policy) override
   {
-    service_registration_policy_str = new_policy;
+    service_relying_party_registration_policy_str = new_policy;
+  }
+
+  virtual std::string platform_relying_party_registration_policy()
+    const override
+  {
+    return platform_relying_party_registration_policy_str;
+  }
+
+  virtual void set_platform_relying_party_registration_policy(
+    const std::string& new_policy) override
+  {
+    platform_relying_party_registration_policy_str = new_policy;
   }
 
   virtual std::string service_relying_party_policy(
@@ -259,6 +278,23 @@ default allow := true
     const std::string& service_name, const std::string& new_policy) override
   {
     service_relying_party_policy_str[service_name] = new_policy;
+  }
+
+  virtual std::string platform_relying_party_policy(
+    const std::string& service_name) const override
+  {
+    auto it = platform_relying_party_policy_str.find(service_name);
+    if (it != platform_relying_party_policy_str.end())
+    {
+      return it->second;
+    }
+    return DEFAULT_PERMISSIVE_RELYING_PARTY_POLICY;
+  }
+
+  virtual void set_platform_relying_party_policy(
+    const std::string& service_name, const std::string& new_policy) override
+  {
+    platform_relying_party_policy_str[service_name] = new_policy;
   }
 
   uint32_t get_fresh_time() override

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -281,9 +281,9 @@ default allow := true
   }
 
   virtual std::string platform_relying_party_policy(
-    const std::string& service_name) const override
+    const std::string& platform) const override
   {
-    auto it = platform_relying_party_policy_str.find(service_name);
+    auto it = platform_relying_party_policy_str.find(platform);
     if (it != platform_relying_party_policy_str.end())
     {
       return it->second;
@@ -292,9 +292,9 @@ default allow := true
   }
 
   virtual void set_platform_relying_party_policy(
-    const std::string& service_name, const std::string& new_policy) override
+    const std::string& platform, const std::string& new_policy) override
   {
-    platform_relying_party_policy_str[service_name] = new_policy;
+    platform_relying_party_policy_str[platform] = new_policy;
   }
 
   uint32_t get_fresh_time() override


### PR DESCRIPTION
Follow up to #38 
- [x] Rename old interfaces and add new ones
- [x] Endpoint to set the platform policy for a service with registration policy check
- [x] Extend e2e tests

UPD
- Renamed service/platform relying party policy -> service/platform definition
- Renamed service/platform relying party registration policy -> service/platform definition auth