### PR TITLE
Rework definition policies properly (service, platform)

### DIFF
--- a/include/attestation.h
+++ b/include/attestation.h
@@ -16,6 +16,7 @@ namespace aDNS
   static ccf::QuoteInfo parse_and_verify_attestation(
     std::string_view raw_attestation,
     ccf::pal::PlatformAttestationReportData& report_data,
+    ccf::pal::PlatformAttestationMeasurement& measurement,
     ccf::pal::UVMEndorsements& uvm_endorsements_descriptor)
   {
     auto attestation =
@@ -41,7 +42,6 @@ namespace aDNS
       // If not, fallback to attempt as byte-encoded chain as is.
     }
 
-    ccf::pal::PlatformAttestationMeasurement measurement = {};
     ccf::pal::verify_quote(attestation, measurement, report_data);
 
     if (attestation.format != ccf::QuoteFormat::insecure_virtual)

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -1884,9 +1884,10 @@ namespace ccfdns
           const auto in = params.get<SetServiceDefinition::In>();
 
           ccf::pal::PlatformAttestationReportData report_data = {};
+          ccf::pal::PlatformAttestationMeasurement& measurement = {};
           ccf::pal::UVMEndorsements uvm_descriptor = {};
           auto attestation = parse_and_verify_attestation(
-            in.attestation, report_data, uvm_descriptor);
+            in.attestation, report_data, measurement, uvm_descriptor);
 
           if (attestation.format != ccf::QuoteFormat::insecure_virtual)
           {
@@ -1928,9 +1929,10 @@ namespace ccfdns
             const auto in = params.get<SetPlatformDefinition::In>();
 
             ccf::pal::PlatformAttestationReportData report_data = {};
+            ccf::pal::PlatformAttestationMeasurement& measurement = {};
             ccf::pal::UVMEndorsements uvm_descriptor = {};
             auto attestation = parse_and_verify_attestation(
-              in.attestation, report_data, uvm_descriptor);
+              in.attestation, report_data, measurement, uvm_descriptor);
 
             if (attestation.format != ccf::QuoteFormat::insecure_virtual)
             {

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -1884,7 +1884,7 @@ namespace ccfdns
           const auto in = params.get<SetServiceDefinition::In>();
 
           ccf::pal::PlatformAttestationReportData report_data = {};
-          ccf::pal::PlatformAttestationMeasurement& measurement = {};
+          ccf::pal::PlatformAttestationMeasurement measurement = {};
           ccf::pal::UVMEndorsements uvm_descriptor = {};
           auto attestation = parse_and_verify_attestation(
             in.attestation, report_data, measurement, uvm_descriptor);
@@ -1929,7 +1929,7 @@ namespace ccfdns
             const auto in = params.get<SetPlatformDefinition::In>();
 
             ccf::pal::PlatformAttestationReportData report_data = {};
-            ccf::pal::PlatformAttestationMeasurement& measurement = {};
+            ccf::pal::PlatformAttestationMeasurement measurement = {};
             ccf::pal::UVMEndorsements uvm_descriptor = {};
             auto attestation = parse_and_verify_attestation(
               in.attestation, report_data, measurement, uvm_descriptor);

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -175,8 +175,10 @@ package policy
 
 default allow := false
 
+allowed_measurements := ["{allowed_measurement}"]
+
 allowed_measurement if {{
-    input.measurement == "{allowed_measurement}"
+    input.measurement in allowed_measurements
 }}
 
 allow if {{


### PR DESCRIPTION
The platform definition policy was wrongly checking `attestation.host_data` against security policy (same as service definition policy), but instead it should check the verified measurement against allowed uvm measurements (and probably other things, but not in this PR).