### PR TITLE
ADNS's KSK as trusted anchor

### DIFF
--- a/demo/bind.sh
+++ b/demo/bind.sh
@@ -8,6 +8,27 @@ nameserver 127.0.0.1
 search .
 EOF
 
+# Get DNSKEY and extract KSK (257)
+KSK=$(dig @127.0.0.1 -p 5353 acidns10.attested.name DNSKEY +short | grep "257 3 14" | sed 's/.*14 //')
+
+# Update trust-anchors with KSK
+cat > named.conf << EOF
+// Forward zone for .acidns10.attested.name domain
+zone "acidns10.attested.name" {
+    type forward;
+    forward only;
+    forwarders {
+        127.0.0.1 port 5353;  // Your ADNS server
+    };
+};
+trust-anchors {
+    "acidns10.attested.name" initial-key 257 3 14 "$KSK";
+};
+options {
+    dnssec-validation yes;
+};
+EOF
+
 # Prepare config.
 cp named.conf /usr/etc/named.conf
 

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -24,8 +24,8 @@ Nit. Setup contains openssl cloning+building, may need intervention if run multi
 In separate terminals, run
 
 ```
-./bind.sh
 ./adns.sh
+./bind.sh # Depends on the previous, as it adds current aDNS KSK as a trusted-anchor
 ./service.sh
 ./resolve.sh
 ```

--- a/demo/named.conf
+++ b/demo/named.conf
@@ -1,7 +1,3 @@
-options {
-    dnssec-validation false;
-};
-
 // Forward zone for .acidns10.attested.name domain
 zone "acidns10.attested.name" {
     type forward;
@@ -9,4 +5,10 @@ zone "acidns10.attested.name" {
     forwarders {
         127.0.0.1 port 5353;  // Your ADNS server
     };
+};
+trust-anchors {
+    "acidns10.attested.name" initial-key 257 3 14 "JLMgaOT3CSU1F+a9xou2kHijviuQTaM4ns1vvUW9Ehl8tTgvdFG//UI7 GbA4MRQcsmcqM7+GUGHMZyQuqgxYPgCjhlIQHg0HNjatCARw+OZ2+RU8 NOYJFhO9aBV2b/c3";
+};
+options {
+    dnssec-validation yes;
 };


### PR DESCRIPTION
Now `bind.sh` asks aDNS instance for it's KSK and pins it as trusted anchor for the domain.