### PR TITLE
Service registration via COSE

### DIFF
--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -171,12 +171,6 @@ namespace aDNS
     Resolver::RegistrationInformation, public_key, csr, node_information);
   DECLARE_JSON_OPTIONAL_FIELDS(
     Resolver::RegistrationInformation, dnskey_records);
-
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Resolver::RegistrationRequest);
-  DECLARE_JSON_REQUIRED_FIELDS(
-    Resolver::RegistrationRequest, csr, node_information);
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    Resolver::RegistrationRequest, configuration_receipt);
 }
 
 namespace ccfdns

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -8,6 +8,7 @@
 
 #include <ccf/crypto/pem.h>
 #include <ccf/ds/json.h>
+#include <ccf/ds/quote_info.h>
 #include <cstdint>
 
 namespace ccfdns
@@ -45,12 +46,6 @@ namespace ccfdns
     using Out = void;
   };
 
-  struct RegisterService
-  {
-    using In = aDNS::Resolver::RegistrationRequest;
-    using Out = void;
-  };
-
   struct Resign
   {
     struct In
@@ -75,7 +70,7 @@ namespace ccfdns
   {
     struct In
     {
-      aDNS::AttestationType platform;
+      ccf::QuoteFormat platform;
       std::string policy;
       std::string attestation;
     };

--- a/include/cose.h
+++ b/include/cose.h
@@ -1,0 +1,547 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache 2.0 License.
+
+#pragma once
+
+#include <ccf/crypto/base64.h>
+#include <ccf/crypto/key_pair.h>
+#include <fmt/format.h>
+#include <qcbor/UsefulBuf.h>
+#include <qcbor/qcbor.h>
+#include <qcbor/qcbor_common.h>
+#include <qcbor/qcbor_decode.h>
+#include <qcbor/qcbor_encode.h>
+#include <qcbor/qcbor_spiffy_decode.h>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace aDNS
+{
+  namespace cose
+  {
+    // COSE/CWT constants
+    static constexpr int64_t COSE_ALG_LABEL = 1;
+    static constexpr int64_t COSE_ALG_ES256 = -7;
+    static constexpr int64_t CWT_CLAIMS_LABEL = 15;
+    static constexpr int64_t CWT_ISS_LABEL = 1;
+    static constexpr int64_t CWT_CNF_LABEL = 8;
+    static constexpr auto CWT_ATT_NAME = "att";
+    static constexpr auto CWT_SVI_NAME = "svi";
+
+    // CNF claim constants
+    static constexpr int64_t CNF_KTY_LABEL = 1;
+    static constexpr int64_t CNF_CRV_LABEL = -1;
+    static constexpr int64_t CNF_X_LABEL = -2;
+    static constexpr int64_t CNF_Y_LABEL = -3;
+
+    // Service info constants
+    static constexpr auto SVI_PORT_NAME = "port";
+    static constexpr auto SVI_PROTOCOL_NAME = "protocol";
+    static constexpr auto SVI_IPV4_NAME = "ipv4";
+
+    static constexpr int64_t UHDR_ENDORSEMENTS = 1;
+
+    // Attestation
+    static constexpr auto PLD_ATTESTATION = "att";
+    static constexpr auto PLD_UVM_ENDORSEMENTS = "uvm";
+    static constexpr auto PLD_ENDORSEMENTS = "eds";
+
+    struct CnfClaim
+    {
+      int64_t kty{};
+      int64_t crv{};
+      std::vector<uint8_t> x{};
+      std::vector<uint8_t> y{};
+    };
+
+    struct ServiceInfo
+    {
+      std::string port{};
+      std::string protocol{};
+      std::string ipv4{};
+    };
+
+    struct CwtClaim
+    {
+      std::string iss{};
+      CnfClaim cnf{};
+      std::string att{};
+      ServiceInfo svi{};
+    };
+
+    struct ProtectedHeader
+    {
+      int64_t alg{};
+      CwtClaim cwt{};
+    };
+
+    struct CoseRequest
+    {
+      ProtectedHeader protected_header{};
+      std::vector<uint8_t> payload{};
+    };
+
+    struct Attestation
+    {
+      std::vector<uint8_t> attestation{};
+      std::vector<uint8_t> uvm_endorsements{};
+      std::string endorsements{};
+    };
+
+    // Helper functions for QCBOR conversions
+    inline UsefulBufC from_bytes(std::span<const uint8_t> v)
+    {
+      return UsefulBufC{v.data(), v.size()};
+    }
+
+    inline UsefulBufC from_string(std::string_view v)
+    {
+      return UsefulBufC{v.data(), v.size()};
+    }
+
+    inline std::vector<uint8_t> as_vector(UsefulBufC buf)
+    {
+      return std::vector<uint8_t>(
+        static_cast<const uint8_t*>(buf.ptr),
+        static_cast<const uint8_t*>(buf.ptr) + buf.len);
+    }
+
+    inline std::span<const uint8_t> as_span(UsefulBufC buf)
+    {
+      return {static_cast<const uint8_t*>(buf.ptr), buf.len};
+    }
+
+    inline std::string_view as_string(UsefulBufC buf)
+    {
+      return {static_cast<const char*>(buf.ptr), buf.len};
+    }
+
+    // COSE parsing function implementations
+    inline CnfClaim parse_cnf_claims(QCBORDecodeContext& ctx)
+    {
+      QCBORDecode_EnterMapFromMapN(&ctx, CWT_CNF_LABEL);
+      auto decode_error = QCBORDecode_GetError(&ctx);
+      if (decode_error != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(
+          fmt::format("Failed to decode CNF claims: {}", decode_error));
+      }
+
+      enum
+      {
+        CNF_KTY_INDEX,
+        CNF_CRV_INDEX,
+        CNF_X_INDEX,
+        CNF_Y_INDEX,
+        CNF_END_INDEX,
+      };
+      QCBORItem cnf_items[CNF_END_INDEX + 1];
+
+      cnf_items[CNF_KTY_INDEX].label.int64 = CNF_KTY_LABEL;
+      cnf_items[CNF_KTY_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cnf_items[CNF_KTY_INDEX].uDataType = QCBOR_TYPE_INT64;
+
+      cnf_items[CNF_CRV_INDEX].label.int64 = CNF_CRV_LABEL;
+      cnf_items[CNF_CRV_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cnf_items[CNF_CRV_INDEX].uDataType = QCBOR_TYPE_INT64;
+
+      cnf_items[CNF_X_INDEX].label.int64 = CNF_X_LABEL;
+      cnf_items[CNF_X_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cnf_items[CNF_X_INDEX].uDataType = QCBOR_TYPE_BYTE_STRING;
+
+      cnf_items[CNF_Y_INDEX].label.int64 = CNF_Y_LABEL;
+      cnf_items[CNF_Y_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cnf_items[CNF_Y_INDEX].uDataType = QCBOR_TYPE_BYTE_STRING;
+
+      cnf_items[CNF_END_INDEX].uLabelType = QCBOR_TYPE_NONE;
+
+      QCBORDecode_GetItemsInMap(&ctx, cnf_items);
+
+      auto qcbor_result = QCBORDecode_GetError(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(fmt::format(
+          "Failed to decode CNF claim: {}", qcbor_err_to_str(qcbor_result)));
+      }
+
+      QCBORDecode_ExitMap(&ctx);
+
+      CnfClaim cnf{};
+
+      if (cnf_items[CNF_KTY_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'kty' in cnf claim");
+      }
+      cnf.kty = cnf_items[CNF_KTY_INDEX].val.int64;
+
+      if (cnf_items[CNF_CRV_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'crv' in cnf claim");
+      }
+      cnf.crv = cnf_items[CNF_CRV_INDEX].val.int64;
+
+      if (cnf_items[CNF_X_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'x' in cnf claim");
+      }
+      cnf.x = as_vector(cnf_items[CNF_X_INDEX].val.string);
+
+      if (cnf_items[CNF_Y_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'y' in cnf claim");
+      }
+      cnf.y = as_vector(cnf_items[CNF_Y_INDEX].val.string);
+
+      return cnf;
+    }
+
+    inline ServiceInfo parse_service_info(QCBORDecodeContext& ctx)
+    {
+      QCBORDecode_EnterMapFromMapSZ(&ctx, "svi");
+      auto decode_error = QCBORDecode_GetError(&ctx);
+      if (decode_error != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(
+          fmt::format("Failed to decode service info: {}", decode_error));
+      }
+
+      enum
+      {
+        SVI_PORT_INDEX,
+        SVI_PROTOCOL_INDEX,
+        SVI_IPV4_INDEX,
+        SVI_END_INDEX,
+      };
+      QCBORItem svi_items[SVI_END_INDEX + 1];
+
+      svi_items[SVI_PORT_INDEX].label.string = UsefulBuf_FromSZ(SVI_PORT_NAME);
+      svi_items[SVI_PORT_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      svi_items[SVI_PORT_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      svi_items[SVI_PROTOCOL_INDEX].label.string =
+        UsefulBuf_FromSZ(SVI_PROTOCOL_NAME);
+      svi_items[SVI_PROTOCOL_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      svi_items[SVI_PROTOCOL_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      svi_items[SVI_IPV4_INDEX].label.string = UsefulBuf_FromSZ(SVI_IPV4_NAME);
+      svi_items[SVI_IPV4_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      svi_items[SVI_IPV4_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      svi_items[SVI_END_INDEX].uLabelType = QCBOR_TYPE_NONE;
+
+      QCBORDecode_GetItemsInMap(&ctx, svi_items);
+
+      auto qcbor_result = QCBORDecode_GetError(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(fmt::format(
+          "Failed to decode service info: {}", qcbor_err_to_str(qcbor_result)));
+      }
+
+      QCBORDecode_ExitMap(&ctx);
+
+      ServiceInfo svi{};
+
+      if (svi_items[SVI_PORT_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'port' in service info");
+      }
+      svi.port = as_string(svi_items[SVI_PORT_INDEX].val.string);
+
+      if (svi_items[SVI_PROTOCOL_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error(
+          "Missing or invalid 'protocol' in service info");
+      }
+      svi.protocol = as_string(svi_items[SVI_PROTOCOL_INDEX].val.string);
+
+      if (svi_items[SVI_IPV4_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'ipv4' in service info");
+      }
+      svi.ipv4 = as_string(svi_items[SVI_IPV4_INDEX].val.string);
+
+      return svi;
+    }
+
+    inline CwtClaim parse_cwt_claims(QCBORDecodeContext& ctx)
+    {
+      QCBORDecode_EnterMapFromMapN(&ctx, CWT_CLAIMS_LABEL);
+      auto decode_error = QCBORDecode_GetError(&ctx);
+      if (decode_error != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(
+          fmt::format("Failed to decode CWT claims: {}", decode_error));
+      }
+
+      enum
+      {
+        CWT_ISS_INDEX,
+        CWT_CNF_INDEX,
+        CWT_ATT_INDEX,
+        CWT_SVI_INDEX,
+        CWT_END_INDEX,
+      };
+
+      QCBORItem cwt_items[CWT_END_INDEX + 1];
+
+      cwt_items[CWT_ISS_INDEX].label.int64 = CWT_ISS_LABEL;
+      cwt_items[CWT_ISS_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cwt_items[CWT_ISS_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      cwt_items[CWT_CNF_INDEX].label.int64 = CWT_CNF_LABEL;
+      cwt_items[CWT_CNF_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cwt_items[CWT_CNF_INDEX].uDataType = QCBOR_TYPE_MAP;
+
+      cwt_items[CWT_ATT_INDEX].label.string = UsefulBuf_FromSZ(CWT_ATT_NAME);
+      cwt_items[CWT_ATT_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      cwt_items[CWT_ATT_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      cwt_items[CWT_SVI_INDEX].label.string = UsefulBuf_FromSZ(CWT_SVI_NAME);
+      cwt_items[CWT_SVI_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      cwt_items[CWT_SVI_INDEX].uDataType = QCBOR_TYPE_MAP;
+
+      cwt_items[CWT_END_INDEX].uLabelType = QCBOR_TYPE_NONE;
+
+      QCBORDecode_GetItemsInMap(&ctx, cwt_items);
+      decode_error = QCBORDecode_GetError(&ctx);
+      if (decode_error != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(
+          fmt::format("Failed to decode CWT claim contents: {}", decode_error));
+      }
+
+      CwtClaim cwt{};
+
+      if (cwt_items[CWT_ISS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'iss' in CWT claims");
+      }
+      cwt.iss = as_string(cwt_items[CWT_ISS_INDEX].val.string);
+
+      if (cwt_items[CWT_CNF_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing 'cnf' in CWT claims");
+      }
+      cwt.cnf = parse_cnf_claims(ctx);
+
+      if (cwt_items[CWT_ATT_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'att' in CWT claims");
+      }
+      cwt.att = as_string(cwt_items[CWT_ATT_INDEX].val.string);
+
+      if (cwt_items[CWT_SVI_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing 'svi' in CWT claims");
+      }
+      cwt.svi = parse_service_info(ctx);
+
+      QCBORDecode_ExitMap(&ctx);
+
+      return cwt;
+    }
+
+    inline ProtectedHeader parse_protected_header_items(QCBORDecodeContext& ctx)
+    {
+      enum
+      {
+        ALG_INDEX,
+        CWT_CLAIMS_INDEX,
+        END_INDEX,
+      };
+      QCBORItem header_items[END_INDEX + 1];
+
+      header_items[ALG_INDEX].label.int64 = COSE_ALG_LABEL;
+      header_items[ALG_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      header_items[ALG_INDEX].uDataType = QCBOR_TYPE_INT64;
+
+      header_items[CWT_CLAIMS_INDEX].label.int64 = CWT_CLAIMS_LABEL;
+      header_items[CWT_CLAIMS_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      header_items[CWT_CLAIMS_INDEX].uDataType = QCBOR_TYPE_MAP;
+
+      header_items[END_INDEX].uLabelType = QCBOR_TYPE_NONE;
+
+      QCBORDecode_GetItemsInMap(&ctx, header_items);
+
+      auto qcbor_result = QCBORDecode_GetError(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(fmt::format(
+          "Failed to decode protected header: {}",
+          qcbor_err_to_str(qcbor_result)));
+      }
+
+      ProtectedHeader phdr{};
+
+      if (header_items[ALG_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error(
+          "Missing or invalid algorithm in protected header");
+      }
+      phdr.alg = header_items[ALG_INDEX].val.int64;
+
+      if (header_items[CWT_CLAIMS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing CWT claims in protected header");
+      }
+
+      phdr.cwt = parse_cwt_claims(ctx);
+
+      return phdr;
+    }
+
+    inline CoseRequest decode_cose_request(std::span<const uint8_t> input)
+    {
+      QCBORError qcbor_result;
+
+      QCBORDecodeContext ctx;
+      QCBORDecode_Init(&ctx, from_bytes(input), QCBOR_DECODE_MODE_NORMAL);
+
+      QCBORDecode_EnterArray(&ctx, nullptr);
+      qcbor_result = QCBORDecode_GetError(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error("Failed to parse COSE_Sign1 outer array");
+      }
+
+      uint64_t tag = QCBORDecode_GetNthTagOfLast(&ctx, 0);
+      if (tag != CBOR_TAG_COSE_SIGN1)
+      {
+        throw std::runtime_error("COSE_Sign1 is not tagged");
+      }
+
+      QCBORDecode_EnterBstrWrapped(&ctx, QCBOR_TAG_REQUIREMENT_NOT_A_TAG, NULL);
+      QCBORDecode_EnterMap(&ctx, NULL);
+
+      ProtectedHeader phdr = parse_protected_header_items(ctx);
+
+      QCBORDecode_ExitMap(&ctx);
+      QCBORDecode_ExitBstrWrapped(&ctx);
+
+      // uhdr
+      QCBORDecode_EnterMap(&ctx, NULL);
+      QCBORDecode_ExitMap(&ctx);
+
+      QCBORItem payload_item;
+      QCBORDecode_GetNext(&ctx, &payload_item);
+
+      if (payload_item.uDataType != QCBOR_TYPE_BYTE_STRING)
+      {
+        throw std::runtime_error("Expected payload to be a byte string");
+      }
+      std::vector<uint8_t> payload = as_vector(payload_item.val.string);
+
+      QCBORDecode_ExitArray(&ctx);
+
+      return CoseRequest{.protected_header = phdr, .payload = payload};
+    }
+
+    inline ccf::crypto::PublicKeyPtr reconstruct_public_key_from_cnf(
+      const CnfClaim& cnf)
+    {
+      if (cnf.kty != 2)
+      {
+        throw std::runtime_error("Unsupported key type, expected EC2");
+      }
+      if (cnf.crv != 1)
+      {
+        throw std::runtime_error("Unsupported curve, expected P-256");
+      }
+      if (cnf.x.size() != 32 || cnf.y.size() != 32)
+      {
+        throw std::runtime_error("Invalid coordinate size for P-256");
+      }
+
+      ccf::crypto::JsonWebKeyECPublic jwk_public;
+      jwk_public.kty = ccf::crypto::JsonWebKeyType::EC;
+      jwk_public.crv = ccf::crypto::JsonWebKeyECCurve::P256;
+      jwk_public.x = ccf::crypto::b64url_from_raw(cnf.x, false);
+      jwk_public.y = ccf::crypto::b64url_from_raw(cnf.y, false);
+
+      return ccf::crypto::make_public_key(jwk_public);
+    }
+
+    inline Attestation parse_attestation(std::span<const uint8_t> attestation)
+    {
+      QCBORDecodeContext ctx;
+      QCBORDecode_Init(&ctx, from_bytes(attestation), QCBOR_DECODE_MODE_NORMAL);
+
+      QCBORDecode_EnterMap(&ctx, NULL);
+
+      enum
+      {
+        ATTESTATION_INDEX,
+        ENDORSEMENTS_INDEX,
+        UVM_ENDORSEMENTS_INDEX,
+        END_INDEX,
+      };
+      QCBORItem header_items[END_INDEX + 1];
+
+      header_items[ATTESTATION_INDEX].label.string =
+        UsefulBuf_FromSZ(PLD_ATTESTATION);
+      header_items[ATTESTATION_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      header_items[ATTESTATION_INDEX].uDataType = QCBOR_TYPE_BYTE_STRING;
+
+      header_items[UVM_ENDORSEMENTS_INDEX].label.string =
+        UsefulBuf_FromSZ(PLD_UVM_ENDORSEMENTS);
+      header_items[UVM_ENDORSEMENTS_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      header_items[UVM_ENDORSEMENTS_INDEX].uDataType = QCBOR_TYPE_BYTE_STRING;
+
+      header_items[ENDORSEMENTS_INDEX].label.string =
+        UsefulBuf_FromSZ(PLD_ENDORSEMENTS);
+      header_items[ENDORSEMENTS_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+      header_items[ENDORSEMENTS_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      header_items[END_INDEX].uLabelType = QCBOR_TYPE_NONE;
+
+      QCBORDecode_GetItemsInMap(&ctx, header_items);
+
+      auto qcbor_result = QCBORDecode_GetError(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(fmt::format(
+          "Failed to decode payload: {}", qcbor_err_to_str(qcbor_result)));
+      }
+
+      std::vector<uint8_t> raw_attestation{}, uvm_endorsements{};
+      std::string endorsements{};
+
+      if (header_items[UVM_ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'uvm' in the payload");
+      }
+      raw_attestation = as_vector(header_items[ATTESTATION_INDEX].val.string);
+
+      if (header_items[UVM_ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'uvm' in the payload");
+      }
+      uvm_endorsements =
+        as_vector(header_items[UVM_ENDORSEMENTS_INDEX].val.string);
+
+      if (header_items[ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      {
+        throw std::runtime_error("Missing or invalid 'eds' in the payload");
+      }
+      endorsements = as_string(header_items[ENDORSEMENTS_INDEX].val.string);
+
+      QCBORDecode_ExitMap(&ctx);
+
+      qcbor_result = QCBORDecode_Finish(&ctx);
+      if (qcbor_result != QCBOR_SUCCESS)
+      {
+        throw std::runtime_error(fmt::format(
+          "Decoding attestation finished with error: {}",
+          qcbor_err_to_str(qcbor_result)));
+      }
+
+      return Attestation{
+        .attestation = raw_attestation,
+        .uvm_endorsements = uvm_endorsements,
+        .endorsements = endorsements};
+    }
+  } // cose
+} // aDNS

--- a/include/cose.h
+++ b/include/cose.h
@@ -444,11 +444,11 @@ namespace aDNS
     {
       if (cnf.kty != 2)
       {
-        throw std::runtime_error("Unsupported key type, expected EC2");
+        throw std::runtime_error("Unsupported key type, expected EC2(2)");
       }
       if (cnf.crv != 1)
       {
-        throw std::runtime_error("Unsupported curve, expected P-256");
+        throw std::runtime_error("Unsupported curve, expected P-256(1)");
       }
       if (cnf.x.size() != 32 || cnf.y.size() != 32)
       {

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -11,6 +11,7 @@
 
 #include <ccf/crypto/key_pair.h>
 #include <ccf/crypto/pem.h>
+#include <ccf/ds/quote_info.h>
 #include <functional>
 #include <memory>
 #include <stdexcept>
@@ -21,16 +22,6 @@ namespace aDNS
   using Message = RFC1035::Message;
   using ResourceRecord = RFC1035::ResourceRecord;
   using CRRS = RFC4034::CRRS;
-
-  enum class AttestationType
-  {
-    SEV_SNP_CONTAINERPLAT_AMD_UVM = 0
-  };
-
-  DECLARE_JSON_ENUM(
-    AttestationType,
-    {{AttestationType::SEV_SNP_CONTAINERPLAT_AMD_UVM,
-      "SEV-SNP:ContainerPlat-AMD-UVM"}});
 
   enum class Type : uint16_t
   {
@@ -120,7 +111,7 @@ namespace aDNS
     {
       NodeAddress address;
       std::string attestation;
-      aDNS::AttestationType attestation_type;
+      ccf::QuoteFormat attestation_type;
     };
 
     struct Configuration
@@ -162,13 +153,6 @@ namespace aDNS
       std::map<std::string, NodeInfo> node_information;
       std::optional<std::vector<aDNS::ResourceRecord>>
         dnskey_records; // to be recorded as DS at the parent
-    };
-
-    struct RegistrationRequest
-    {
-      std::vector<uint8_t> csr;
-      std::map<std::string, NodeInfo> node_information;
-      std::optional<std::string> configuration_receipt;
     };
 
     struct Resolution
@@ -259,7 +243,7 @@ namespace aDNS
       const ccf::crypto::Pem& pem,
       bool key_signing) = 0;
 
-    virtual void register_service(const RegistrationRequest& req);
+    virtual void register_service(const std::vector<uint8_t>& req);
 
     virtual std::string service_definition_auth() const = 0;
 
@@ -288,7 +272,7 @@ namespace aDNS
     virtual uint32_t get_fresh_time() = 0;
 
     virtual void save_service_registration_request(
-      const Name& name, const RegistrationRequest& rr) = 0;
+      const Name& name, const std::vector<uint8_t>& rr) = 0;
 
     virtual std::map<std::string, NodeInfo> get_node_information() = 0;
 

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1638,7 +1638,9 @@ namespace aDNS
         configuration.default_ttl,
         RFC1035::A(phdr.cwt.svi.ipv4)));
 
-    std::string prolow = ccf::nonstd::to_lower(phdr.cwt.svi.protocol);
+    std::string prolow = phdr.cwt.svi.protocol;
+    ccf::nonstd::to_lower(prolow);
+
     auto tlsa_name =
       Name("_" + phdr.cwt.svi.port) + Name(std::string("_") + prolow) + name;
 

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1643,8 +1643,7 @@ namespace aDNS
         configuration.default_ttl,
         RFC1035::A(phdr.cwt.svi.ipv4)));
 
-    std::string prolow = phdr.cwt.svi.protocol;
-    std::transform(prolow.begin(), prolow.end(), prolow.begin(), ::tolower);
+    std::string prolow = ccf::nonstd::to_lower(phdr.cwt.svi.protocol);
     auto tlsa_name =
       Name("_" + phdr.cwt.svi.port) + Name(std::string("_") + prolow) + name;
 

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1512,9 +1512,6 @@ namespace aDNS
 
     auto public_key_digest = ccf::crypto::sha256(public_key->public_key_der());
 
-    small_vector<uint16_t> public_key_sv(
-      public_key_digest.size(), public_key_digest.data());
-
     ccf::QuoteInfo attestation;
     ccf::pal::PlatformAttestationReportData report_data = {};
     ccf::pal::UVMEndorsements uvm_endorsements_descriptor = {};
@@ -1576,10 +1573,9 @@ namespace aDNS
         report_data.data.end(),
         [](uint8_t b) { return b == 0; }))
     {
-      throw std::runtime_error(
-        fmt::format(
-          "ADNS: Attestation report data for {} is not zeroed after key hash",
-          std::string(service_name)));
+      throw std::runtime_error(fmt::format(
+        "ADNS: Attestation report data for {} is not zeroed after key hash",
+        std::string(service_name)));
     }
 
     Name service_name(phdr.cwt.iss);
@@ -1647,6 +1643,8 @@ namespace aDNS
     auto tlsa_name =
       Name("_" + phdr.cwt.svi.port) + Name(std::string("_") + prolow) + name;
 
+    small_vector<uint16_t> public_key_sv(
+      public_key_digest.size(), public_key_digest.data());
     ResourceRecord tlsa_rr = mk_rr(
       tlsa_name,
       Type::TLSA,

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1573,9 +1573,8 @@ namespace aDNS
         report_data.data.end(),
         [](uint8_t b) { return b == 0; }))
     {
-      throw std::runtime_error(fmt::format(
-        "ADNS: Attestation report data for {} is not zeroed after key hash",
-        std::string(service_name)));
+      throw std::runtime_error(
+        "ADNS: Attestation report data for is not zeroed after key hash");
     }
 
     Name service_name(phdr.cwt.iss);

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,3 +20,4 @@ pyOpenSSL
 dnspython[doh,dnssec]
 dnsstamps
 requests
+cwt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,4 +20,4 @@ pyOpenSSL
 dnspython[doh,dnssec]
 dnsstamps
 requests
-cwt
+cwt>3.1


### PR DESCRIPTION
Resolves #36 

Changelog (at the moment of publishing this PR)
- Service registration request format changed
  - All COSE
  - Attestation passed as a nested COSE (payload)
  - CCFs attestation format enum reused, hence `aDNS::AttestationType` was removed
  - Registration receipt endpoint got removed too as never used. `read_ledger.py` will be wrapped to for demo purposes if needed
  - The request itself is saved in the ledger (not mapped to a custom ledger map anymore)
- Testing infra changes, as required
- Added lots of `qcbor`/`tcose`, wrapped in `cose.h` for convenience.

Follow-up: #66 