### PR TITLE
All COSE endpoints and configuration

### DIFF
--- a/include/ccfdns_json.h
+++ b/include/ccfdns_json.h
@@ -140,10 +140,6 @@ namespace RFC5155
 
 namespace aDNS
 {
-  DECLARE_JSON_TYPE(Resolver::Configuration::ServiceCA);
-  DECLARE_JSON_REQUIRED_FIELDS(
-    Resolver::Configuration::ServiceCA, name, directory, ca_certificates);
-
   DECLARE_JSON_TYPE(Resolver::NodeAddress);
   DECLARE_JSON_REQUIRED_FIELDS(Resolver::NodeAddress, name, ip, protocol, port);
 
@@ -165,30 +161,12 @@ namespace aDNS
     nsec3_salt_length,
     node_addresses);
   DECLARE_JSON_OPTIONAL_FIELDS(Resolver::Configuration, alternative_names);
-
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Resolver::RegistrationInformation);
-  DECLARE_JSON_REQUIRED_FIELDS(
-    Resolver::RegistrationInformation, public_key, csr, node_information);
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    Resolver::RegistrationInformation, dnskey_records);
 }
 
 namespace ccfdns
 {
   DECLARE_JSON_TYPE(KeyInfo);
   DECLARE_JSON_REQUIRED_FIELDS(KeyInfo, tag, key);
-
-  DECLARE_JSON_TYPE(Configure::Out);
-  DECLARE_JSON_REQUIRED_FIELDS(Configure::Out, registration_info);
-
-  DECLARE_JSON_TYPE(AddRecord::In);
-  DECLARE_JSON_REQUIRED_FIELDS(AddRecord::In, origin, record);
-
-  DECLARE_JSON_TYPE(RemoveAll::In);
-  DECLARE_JSON_REQUIRED_FIELDS(RemoveAll::In, origin, name, class_, type);
-
-  DECLARE_JSON_TYPE(Resign::In);
-  DECLARE_JSON_REQUIRED_FIELDS(Resign::In, origin);
 
   DECLARE_JSON_TYPE(SetServiceDefinition::In);
   DECLARE_JSON_REQUIRED_FIELDS(

--- a/include/ccfdns_rpc_types.h
+++ b/include/ccfdns_rpc_types.h
@@ -13,48 +13,6 @@
 
 namespace ccfdns
 {
-  struct Configure
-  {
-    using In = aDNS::Resolver::Configuration;
-    struct Out
-    {
-      aDNS::Resolver::RegistrationInformation registration_info;
-    };
-  };
-
-  struct AddRecord
-  {
-    struct In
-    {
-      aDNS::Name origin;
-      aDNS::ResourceRecord record;
-    };
-    using Out = void;
-  };
-
-  typedef AddRecord RemoveRecord;
-
-  struct RemoveAll
-  {
-    struct In
-    {
-      aDNS::Name origin;
-      aDNS::Name name;
-      uint16_t class_;
-      uint16_t type;
-    };
-    using Out = void;
-  };
-
-  struct Resign
-  {
-    struct In
-    {
-      std::string origin;
-    };
-    using Out = void;
-  };
-
   struct SetServiceDefinition
   {
     struct In

--- a/include/cose.h
+++ b/include/cose.h
@@ -24,7 +24,8 @@ namespace aDNS
     // COSE/CWT constants
     static constexpr int64_t COSE_ALG_LABEL = 1;
     static constexpr int64_t COSE_ALG_ES256 = -7;
-    static constexpr int64_t CWT_CLAIMS_LABEL = 15;
+    static constexpr int64_t COSE_CWT_LABEL = 15;
+    static constexpr int64_t COSE_X5C_LABEL = 33;
     static constexpr int64_t CWT_ISS_LABEL = 1;
     static constexpr int64_t CWT_SUB_LABEL = 2;
     static constexpr int64_t CWT_CNF_LABEL = 8;
@@ -77,6 +78,7 @@ namespace aDNS
     {
       int64_t alg{};
       CwtClaim cwt{};
+      std::vector<std::vector<uint8_t>> x5chain{};
     };
 
     struct CoseRequest
@@ -118,6 +120,57 @@ namespace aDNS
     inline std::string_view as_string(UsefulBufC buf)
     {
       return {static_cast<const char*>(buf.ptr), buf.len};
+    }
+
+    inline std::vector<std::vector<uint8_t>> decode_x5chain(
+      QCBORDecodeContext& ctx, const QCBORItem& x5chain)
+    {
+      std::vector<std::vector<uint8_t>> parsed;
+
+      if (x5chain.uDataType == QCBOR_TYPE_ARRAY)
+      {
+        QCBORDecode_EnterArrayFromMapN(&ctx, COSE_X5C_LABEL);
+        while (true)
+        {
+          QCBORItem item;
+          auto result = QCBORDecode_GetNext(&ctx, &item);
+          if (result == QCBOR_ERR_NO_MORE_ITEMS)
+          {
+            break;
+          }
+          if (result != QCBOR_SUCCESS)
+          {
+            throw std::runtime_error("Item in x5chain is not well-formed.");
+          }
+          if (item.uDataType == QCBOR_TYPE_BYTE_STRING)
+          {
+            parsed.push_back(as_vector(item.val.string));
+          }
+          else
+          {
+            throw std::runtime_error(
+              "Next item in x5chain was not of type byte string.");
+          }
+        }
+        QCBORDecode_ExitArray(&ctx);
+        if (parsed.empty())
+        {
+          throw std::runtime_error(
+            "x5chain array length was 0 in COSE header.");
+        }
+      }
+      else if (x5chain.uDataType == QCBOR_TYPE_BYTE_STRING)
+      {
+        parsed.push_back(as_vector(x5chain.val.string));
+      }
+      else
+      {
+        throw std::runtime_error(
+          "Value type of x5chain in COSE header is not array or byte "
+          "string.");
+      }
+
+      return parsed;
     }
 
     // COSE parsing function implementations
@@ -262,7 +315,7 @@ namespace aDNS
 
     inline CwtClaim parse_cwt_claims(QCBORDecodeContext& ctx)
     {
-      QCBORDecode_EnterMapFromMapN(&ctx, CWT_CLAIMS_LABEL);
+      QCBORDecode_EnterMapFromMapN(&ctx, COSE_CWT_LABEL);
       auto decode_error = QCBORDecode_GetError(&ctx);
       if (decode_error != QCBOR_SUCCESS)
       {
@@ -350,6 +403,7 @@ namespace aDNS
       {
         ALG_INDEX,
         CWT_CLAIMS_INDEX,
+        X5CHAIN_INDEX,
         END_INDEX,
       };
       QCBORItem header_items[END_INDEX + 1];
@@ -358,9 +412,13 @@ namespace aDNS
       header_items[ALG_INDEX].uLabelType = QCBOR_TYPE_INT64;
       header_items[ALG_INDEX].uDataType = QCBOR_TYPE_INT64;
 
-      header_items[CWT_CLAIMS_INDEX].label.int64 = CWT_CLAIMS_LABEL;
+      header_items[CWT_CLAIMS_INDEX].label.int64 = COSE_CWT_LABEL;
       header_items[CWT_CLAIMS_INDEX].uLabelType = QCBOR_TYPE_INT64;
       header_items[CWT_CLAIMS_INDEX].uDataType = QCBOR_TYPE_MAP;
+
+      header_items[X5CHAIN_INDEX].label.int64 = COSE_X5C_LABEL;
+      header_items[X5CHAIN_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      header_items[X5CHAIN_INDEX].uDataType = QCBOR_TYPE_ANY;
 
       header_items[END_INDEX].uLabelType = QCBOR_TYPE_NONE;
 
@@ -384,6 +442,11 @@ namespace aDNS
       if (header_items[CWT_CLAIMS_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
         phdr.cwt = parse_cwt_claims(ctx);
+      }
+
+      if (header_items[X5CHAIN_INDEX].uDataType != QCBOR_TYPE_NONE)
+      {
+        phdr.x5chain = decode_x5chain(ctx, header_items[X5CHAIN_INDEX]);
       }
 
       return phdr;

--- a/include/cose.h
+++ b/include/cose.h
@@ -26,6 +26,7 @@ namespace aDNS
     static constexpr int64_t COSE_ALG_ES256 = -7;
     static constexpr int64_t CWT_CLAIMS_LABEL = 15;
     static constexpr int64_t CWT_ISS_LABEL = 1;
+    static constexpr int64_t CWT_SUB_LABEL = 2;
     static constexpr int64_t CWT_CNF_LABEL = 8;
     static constexpr auto CWT_ATT_NAME = "att";
     static constexpr auto CWT_SVI_NAME = "svi";
@@ -66,6 +67,7 @@ namespace aDNS
     struct CwtClaim
     {
       std::string iss{};
+      std::string sub{};
       CnfClaim cnf{};
       std::string att{};
       ServiceInfo svi{};
@@ -170,29 +172,25 @@ namespace aDNS
 
       CnfClaim cnf{};
 
-      if (cnf_items[CNF_KTY_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cnf_items[CNF_KTY_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'kty' in cnf claim");
+        cnf.kty = cnf_items[CNF_KTY_INDEX].val.int64;
       }
-      cnf.kty = cnf_items[CNF_KTY_INDEX].val.int64;
 
-      if (cnf_items[CNF_CRV_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cnf_items[CNF_CRV_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'crv' in cnf claim");
+        cnf.crv = cnf_items[CNF_CRV_INDEX].val.int64;
       }
-      cnf.crv = cnf_items[CNF_CRV_INDEX].val.int64;
 
-      if (cnf_items[CNF_X_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cnf_items[CNF_X_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'x' in cnf claim");
+        cnf.x = as_vector(cnf_items[CNF_X_INDEX].val.string);
       }
-      cnf.x = as_vector(cnf_items[CNF_X_INDEX].val.string);
 
-      if (cnf_items[CNF_Y_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cnf_items[CNF_Y_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'y' in cnf claim");
+        cnf.y = as_vector(cnf_items[CNF_Y_INDEX].val.string);
       }
-      cnf.y = as_vector(cnf_items[CNF_Y_INDEX].val.string);
 
       return cnf;
     }
@@ -244,24 +242,20 @@ namespace aDNS
 
       ServiceInfo svi{};
 
-      if (svi_items[SVI_PORT_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (svi_items[SVI_PORT_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'port' in service info");
+        svi.port = as_string(svi_items[SVI_PORT_INDEX].val.string);
       }
-      svi.port = as_string(svi_items[SVI_PORT_INDEX].val.string);
 
-      if (svi_items[SVI_PROTOCOL_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (svi_items[SVI_PROTOCOL_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error(
-          "Missing or invalid 'protocol' in service info");
+        svi.protocol = as_string(svi_items[SVI_PROTOCOL_INDEX].val.string);
       }
-      svi.protocol = as_string(svi_items[SVI_PROTOCOL_INDEX].val.string);
 
-      if (svi_items[SVI_IPV4_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (svi_items[SVI_IPV4_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'ipv4' in service info");
+        svi.ipv4 = as_string(svi_items[SVI_IPV4_INDEX].val.string);
       }
-      svi.ipv4 = as_string(svi_items[SVI_IPV4_INDEX].val.string);
 
       return svi;
     }
@@ -279,6 +273,7 @@ namespace aDNS
       enum
       {
         CWT_ISS_INDEX,
+        CWT_SUB_INDEX,
         CWT_CNF_INDEX,
         CWT_ATT_INDEX,
         CWT_SVI_INDEX,
@@ -290,6 +285,10 @@ namespace aDNS
       cwt_items[CWT_ISS_INDEX].label.int64 = CWT_ISS_LABEL;
       cwt_items[CWT_ISS_INDEX].uLabelType = QCBOR_TYPE_INT64;
       cwt_items[CWT_ISS_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+      cwt_items[CWT_SUB_INDEX].label.int64 = CWT_SUB_LABEL;
+      cwt_items[CWT_SUB_INDEX].uLabelType = QCBOR_TYPE_INT64;
+      cwt_items[CWT_SUB_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
 
       cwt_items[CWT_CNF_INDEX].label.int64 = CWT_CNF_LABEL;
       cwt_items[CWT_CNF_INDEX].uLabelType = QCBOR_TYPE_INT64;
@@ -315,29 +314,30 @@ namespace aDNS
 
       CwtClaim cwt{};
 
-      if (cwt_items[CWT_ISS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cwt_items[CWT_ISS_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'iss' in CWT claims");
+        cwt.iss = as_string(cwt_items[CWT_ISS_INDEX].val.string);
       }
-      cwt.iss = as_string(cwt_items[CWT_ISS_INDEX].val.string);
 
-      if (cwt_items[CWT_CNF_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cwt_items[CWT_SUB_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing 'cnf' in CWT claims");
+        cwt.sub = as_string(cwt_items[CWT_SUB_INDEX].val.string);
       }
-      cwt.cnf = parse_cnf_claims(ctx);
 
-      if (cwt_items[CWT_ATT_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cwt_items[CWT_CNF_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'att' in CWT claims");
+        cwt.cnf = parse_cnf_claims(ctx);
       }
-      cwt.att = as_string(cwt_items[CWT_ATT_INDEX].val.string);
 
-      if (cwt_items[CWT_SVI_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (cwt_items[CWT_ATT_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing 'svi' in CWT claims");
+        cwt.att = as_string(cwt_items[CWT_ATT_INDEX].val.string);
       }
-      cwt.svi = parse_service_info(ctx);
+
+      if (cwt_items[CWT_SVI_INDEX].uDataType != QCBOR_TYPE_NONE)
+      {
+        cwt.svi = parse_service_info(ctx);
+      }
 
       QCBORDecode_ExitMap(&ctx);
 
@@ -376,19 +376,15 @@ namespace aDNS
 
       ProtectedHeader phdr{};
 
-      if (header_items[ALG_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (header_items[ALG_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error(
-          "Missing or invalid algorithm in protected header");
-      }
-      phdr.alg = header_items[ALG_INDEX].val.int64;
-
-      if (header_items[CWT_CLAIMS_INDEX].uDataType == QCBOR_TYPE_NONE)
-      {
-        throw std::runtime_error("Missing CWT claims in protected header");
+        phdr.alg = header_items[ALG_INDEX].val.int64;
       }
 
-      phdr.cwt = parse_cwt_claims(ctx);
+      if (header_items[CWT_CLAIMS_INDEX].uDataType != QCBOR_TYPE_NONE)
+      {
+        phdr.cwt = parse_cwt_claims(ctx);
+      }
 
       return phdr;
     }
@@ -509,24 +505,21 @@ namespace aDNS
       std::vector<uint8_t> raw_attestation{}, uvm_endorsements{};
       std::string endorsements{};
 
-      if (header_items[UVM_ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (header_items[ATTESTATION_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'uvm' in the payload");
+        raw_attestation = as_vector(header_items[ATTESTATION_INDEX].val.string);
       }
-      raw_attestation = as_vector(header_items[ATTESTATION_INDEX].val.string);
 
-      if (header_items[UVM_ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (header_items[UVM_ENDORSEMENTS_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'uvm' in the payload");
+        uvm_endorsements =
+          as_vector(header_items[UVM_ENDORSEMENTS_INDEX].val.string);
       }
-      uvm_endorsements =
-        as_vector(header_items[UVM_ENDORSEMENTS_INDEX].val.string);
 
-      if (header_items[ENDORSEMENTS_INDEX].uDataType == QCBOR_TYPE_NONE)
+      if (header_items[ENDORSEMENTS_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
-        throw std::runtime_error("Missing or invalid 'eds' in the payload");
+        endorsements = as_string(header_items[ENDORSEMENTS_INDEX].val.string);
       }
-      endorsements = as_string(header_items[ENDORSEMENTS_INDEX].val.string);
 
       QCBORDecode_ExitMap(&ctx);
 

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -118,41 +118,19 @@ namespace aDNS
     {
       Name origin; // domain name suffix of the zone served by this resolver
       std::string soa; // serialized SOA record data for the zone
-
       std::optional<std::vector<Name>> alternative_names;
-
       uint32_t default_ttl = 86400;
       RFC4034::Algorithm signing_algorithm =
         RFC4034::Algorithm::ECDSAP384SHA384;
       RFC4034::DigestType digest_type = RFC4034::DigestType::SHA384;
       bool use_key_signing_key = true;
-
       bool use_nsec3 = true;
       RFC5155::HashAlgorithm nsec3_hash_algorithm =
         RFC5155::HashAlgorithm::SHA1;
       uint16_t nsec3_hash_iterations = 3;
       uint8_t nsec3_salt_length = 8;
-
-      struct ServiceCA
-      {
-        std::string name;
-        std::string directory;
-        std::vector<std::string> ca_certificates;
-      };
-
-      ServiceCA service_ca;
-
       // DNS hosts, indexed by CCF node IDs
       std::map<std::string, NodeAddress> node_addresses;
-    };
-
-    struct RegistrationInformation
-    {
-      std::string public_key;
-      std::vector<uint8_t> csr;
-      std::map<std::string, NodeInfo> node_information;
-      std::optional<std::vector<aDNS::ResourceRecord>>
-        dnskey_records; // to be recorded as DS at the parent
     };
 
     struct Resolution
@@ -170,7 +148,7 @@ namespace aDNS
 
     virtual ~Resolver();
 
-    virtual void configure(const Configuration& cfg);
+    virtual void configure();
 
     struct Reply
     {

--- a/include/resolver.h
+++ b/include/resolver.h
@@ -170,7 +170,7 @@ namespace aDNS
 
     virtual ~Resolver();
 
-    virtual RegistrationInformation configure(const Configuration& cfg);
+    virtual void configure(const Configuration& cfg);
 
     struct Reply
     {

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -1494,7 +1494,7 @@ namespace ccfdns
           const auto& platform = as_cose.protected_header.cwt.sub;
           if (platform.empty())
           {
-            throw std::runtime_error("Missing service name (sub)");
+            throw std::runtime_error("Missing platform name (sub)");
           }
 
           ccfdns->set_platform_definition(platform, new_policy);

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -136,7 +136,7 @@ namespace
     std::string_view policy, const cose::ProtectedHeader& phdr)
   {
     nlohmann::json rego_input;
-    rego_input["iss"] = phdr.cwt.iss;
+    rego_input["phdr"]["cwt"]["iss"] = phdr.cwt.iss;
 
     rego::Interpreter interpreter(true /* v1 compatible */);
     auto rv = interpreter.add_module("policy", std::string(policy));

--- a/src/ccfdns.cpp
+++ b/src/ccfdns.cpp
@@ -4,6 +4,8 @@
 #include "attestation.h"
 #include "ccfdns_json.h"
 #include "ccfdns_rpc_types.h"
+#include "cose.h"
+#include "didx509cpp/didx509cpp.h"
 #include "formatting.h"
 #include "keys.h"
 #include "resolver.h"
@@ -16,6 +18,7 @@
 #include <ccf/app_interface.h>
 #include <ccf/base_endpoint_registry.h>
 #include <ccf/common_auth_policies.h>
+#include <ccf/crypto/cose_verifier.h>
 #include <ccf/ds/hex.h>
 #include <ccf/ds/json.h>
 #include <ccf/ds/logger.h>
@@ -128,6 +131,77 @@ namespace
     // Currently reuse service relying party logic, because input is the same.
     verify_against_service_registration_policy(policy, uvm_descriptor);
   }
+
+  void verify_against_auth_policy(
+    std::string_view policy, const std::string& verified_did)
+  {
+    CCF_APP_INFO("Verifying DID {} against policy {}", verified_did, policy);
+
+    nlohmann::json rego_input;
+    rego_input["iss"] = verified_did;
+
+    rego::Interpreter interpreter(true /* v1 compatible */);
+    auto rv = interpreter.add_module("policy", std::string(policy));
+
+    auto tv = interpreter.set_input_term(rego_input.dump());
+    if (tv != nullptr)
+    {
+      throw std::runtime_error(
+        fmt::format("Invalid policy input: {}", rego_input.dump()));
+    }
+
+    auto qv = interpreter.query("data.policy.allow");
+
+    if (qv == "{\"expressions\":[true]}")
+    {
+      return;
+    }
+    else if (qv == "{\"expressions\":[false]}")
+    {
+      throw std::runtime_error(
+        fmt::format("Policy not satisfied: {}", rego_input.dump()));
+    }
+    else
+    {
+      throw std::runtime_error(
+        fmt::format("Error while applying policy: {}", qv));
+    }
+  }
+
+  std::string get_verified_did(const cose::CoseRequest& as_cose)
+  {
+    std::string pem_chain;
+    for (auto const& c : as_cose.protected_header.x5chain)
+    {
+      pem_chain += ccf::crypto::cert_der_to_pem(c).str();
+    }
+
+    auto did_document_str = didx509::resolve(
+      pem_chain,
+      as_cose.protected_header.cwt.iss,
+      true /* Do not validate time */);
+
+    CCF_APP_INFO("Resolved DID document: {}", did_document_str);
+
+    auto as_json = nlohmann::json::parse(did_document_str);
+    return as_json["verificationMethod"][0]["controller"];
+  }
+
+  cose::CoseRequest get_verified_cose(const std::vector<uint8_t>& body)
+  {
+    auto as_cose = cose::decode_cose_request(body);
+    const auto& x5chain = as_cose.protected_header.x5chain;
+    if (x5chain.empty())
+    {
+      throw std::runtime_error("expected a valid x5chain entry, got empty one");
+    }
+
+    auto cose_verifier = ccf::crypto::make_cose_verifier_from_cert(x5chain[0]);
+    std::span<uint8_t> authned_content{};
+    cose_verifier->verify(body, authned_content);
+
+    return as_cose;
+  }
 }
 
 namespace ccfdns
@@ -162,22 +236,19 @@ namespace ccfdns
     const std::string service_certificates_table_name =
       "public:service_certificates";
 
-    using ServiceRelyingPartyRegistrationPolicy =
-      ccf::ServiceValue<std::string>;
+    using ServiceDefinitionAuth = ccf::ServiceValue<std::string>;
     const std::string service_definition_auth_table_name =
       "public:ccf.gov.ccfdns.service_definition_auth";
 
-    using ServiceRelyingPartyPolicy = ccf::ServiceMap<std::string, std::string>;
+    using ServiceDefinition = ccf::ServiceMap<std::string, std::string>;
     const std::string service_definition_table_name =
       "public:ccf.gov.ccfdns.service_definition";
 
-    using PlatformRelyingPartyRegistrationPolicy =
-      ccf::ServiceValue<std::string>;
+    using PlatformDefinitionAuth = ccf::ServiceValue<std::string>;
     const std::string platform_definition_auth_table_name =
       "public:ccf.gov.ccfdns.platform_definition_auth";
 
-    using PlatformRelyingPartyPolicy =
-      ccf::ServiceMap<std::string, std::string>;
+    using PlatformDefinition = ccf::ServiceMap<std::string, std::string>;
     const std::string platform_definition_table_name =
       "public:ccf.gov.ccfdns.platform_definition";
 
@@ -539,12 +610,11 @@ namespace ccfdns
     {
       check_context();
 
-      auto policy_table = rotx().ro<ServiceRelyingPartyRegistrationPolicy>(
-        service_definition_auth_table_name);
+      auto policy_table =
+        rotx().ro<ServiceDefinitionAuth>(service_definition_auth_table_name);
       const std::optional<std::string> policy = policy_table->get();
       if (!policy)
-        throw std::runtime_error(
-          "no service relying party registration policy");
+        throw std::runtime_error("no service definition auth");
       return *policy;
     }
 
@@ -553,12 +623,12 @@ namespace ccfdns
     {
       check_context();
 
-      auto policy = rwtx().rw<ServiceRelyingPartyRegistrationPolicy>(
-        service_definition_auth_table_name);
+      auto policy =
+        rwtx().rw<ServiceDefinitionAuth>(service_definition_auth_table_name);
 
       if (!policy)
         throw std::runtime_error(
-          "error accessing service relying party registration policy table");
+          "error accessing service definition auth table");
 
       policy->put(new_policy);
     }
@@ -569,10 +639,10 @@ namespace ccfdns
       check_context();
 
       auto policy_table =
-        rotx().ro<ServiceRelyingPartyPolicy>(service_definition_table_name);
+        rotx().ro<ServiceDefinition>(service_definition_table_name);
       const std::optional<std::string> policy = policy_table->get(service_name);
       if (!policy)
-        throw std::runtime_error("no service relying party policy");
+        throw std::runtime_error("no service definition");
       return *policy;
     }
 
@@ -581,12 +651,10 @@ namespace ccfdns
     {
       check_context();
 
-      auto policy =
-        rwtx().rw<ServiceRelyingPartyPolicy>(service_definition_table_name);
+      auto policy = rwtx().rw<ServiceDefinition>(service_definition_table_name);
 
       if (!policy)
-        throw std::runtime_error(
-          "error accessing service relying party policy table");
+        throw std::runtime_error("error accessing service definition table");
 
       policy->put(service_name, new_policy);
     }
@@ -595,12 +663,11 @@ namespace ccfdns
     {
       check_context();
 
-      auto policy_table = rotx().ro<PlatformRelyingPartyRegistrationPolicy>(
-        platform_definition_auth_table_name);
+      auto policy_table =
+        rotx().ro<PlatformDefinitionAuth>(platform_definition_auth_table_name);
       const std::optional<std::string> policy = policy_table->get();
       if (!policy)
-        throw std::runtime_error(
-          "no platform relying party registration policy");
+        throw std::runtime_error("no platform defintion auth policy");
       return *policy;
     }
 
@@ -609,12 +676,12 @@ namespace ccfdns
     {
       check_context();
 
-      auto policy = rwtx().rw<PlatformRelyingPartyRegistrationPolicy>(
-        platform_definition_auth_table_name);
+      auto policy =
+        rwtx().rw<PlatformDefinitionAuth>(platform_definition_auth_table_name);
 
       if (!policy)
         throw std::runtime_error(
-          "error accessing platform relying party registration policy table");
+          "error accessing platform definition auth table");
 
       policy->put(new_policy);
     }
@@ -625,10 +692,11 @@ namespace ccfdns
       check_context();
 
       auto policy_table =
-        rotx().ro<PlatformRelyingPartyPolicy>(platform_definition_table_name);
+        rotx().ro<PlatformDefinition>(platform_definition_table_name);
       const std::optional<std::string> policy = policy_table->get(platform);
       if (!policy)
-        throw std::runtime_error("no platform relying party policy");
+        throw std::runtime_error("no platform definition");
+
       return *policy;
     }
 
@@ -638,11 +706,10 @@ namespace ccfdns
       check_context();
 
       auto policy =
-        rwtx().rw<PlatformRelyingPartyPolicy>(platform_definition_table_name);
+        rwtx().rw<PlatformDefinition>(platform_definition_table_name);
 
       if (!policy)
-        throw std::runtime_error(
-          "error accessing platform relying party policy table");
+        throw std::runtime_error("error accessing platform definition table");
 
       policy->put(platform, new_policy);
     }
@@ -1368,96 +1435,152 @@ namespace ccfdns
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
         .install();
 
-      auto set_service_definition = [this](auto& ctx, nlohmann::json&& params) {
+      auto set_service_definition = [this](auto& ctx) {
         try
         {
           ContextContext cc(ccfdns, ctx);
-          ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::TEXT);
+          const auto& body = ctx.rpc_ctx->get_request_body();
 
-          const auto in = params.get<SetServiceDefinition::In>();
+          auto as_cose = cose::decode_cose_request(body);
+          auto did = get_verified_did(as_cose);
+          auto policy = ccfdns->service_definition_auth();
 
-          ccf::pal::PlatformAttestationReportData report_data = {};
-          ccf::pal::PlatformAttestationMeasurement measurement = {};
-          ccf::pal::UVMEndorsements uvm_descriptor = {};
-          auto attestation = parse_and_verify_attestation(
-            in.attestation, report_data, measurement, uvm_descriptor);
+          verify_against_auth_policy(policy, did);
 
-          if (attestation.format != ccf::QuoteFormat::insecure_virtual)
+          const auto& service_name = as_cose.protected_header.cwt.sub;
+          if (service_name.empty())
           {
-            verify_against_service_registration_policy(
-              ccfdns->service_definition_auth(), uvm_descriptor);
+            throw std::runtime_error("Missing service name (sub)");
           }
 
-          ccfdns->set_service_definition(in.service_name, in.policy);
+          auto new_policy =
+            std::string(as_cose.payload.begin(), as_cose.payload.end());
+          CCF_APP_INFO("New policy is: {}", new_policy);
 
-          return ccf::make_success();
+          ccfdns->set_service_definition(service_name, new_policy);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
         }
         catch (std::exception& ex)
         {
-          return ccf::make_error(
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            ccf::errors::InternalError,
-            ex.what());
+          ctx.rpc_ctx->set_response_body(ex.what());
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
         }
       };
 
       make_endpoint(
         "/set-service-definition",
         HTTP_POST,
-        ccf::json_adapter(set_service_definition),
+        set_service_definition,
         ccf::no_auth_required)
-        .set_auto_schema<SetServiceDefinition::In, SetServiceDefinition::Out>()
-        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
         .install();
 
-      auto set_platform_definition =
-        [this](auto& ctx, nlohmann::json&& params) {
-          try
+      auto set_platform_definition = [this](auto& ctx) {
+        try
+        {
+          ContextContext cc(ccfdns, ctx);
+          const auto& body = ctx.rpc_ctx->get_request_body();
+
+          auto as_cose = cose::decode_cose_request(body);
+          auto did = get_verified_did(as_cose);
+          auto policy = ccfdns->platform_definition_auth();
+
+          verify_against_auth_policy(policy, did);
+
+          auto new_policy =
+            std::string(as_cose.payload.begin(), as_cose.payload.end());
+          CCF_APP_INFO("New policy is: {}", new_policy);
+
+          const auto& platform = as_cose.protected_header.cwt.sub;
+          if (platform.empty())
           {
-            ContextContext cc(ccfdns, ctx);
-            ctx.rpc_ctx->set_response_header(
-              ccf::http::headers::CONTENT_TYPE,
-              ccf::http::headervalues::contenttype::TEXT);
-
-            const auto in = params.get<SetPlatformDefinition::In>();
-
-            ccf::pal::PlatformAttestationReportData report_data = {};
-            ccf::pal::PlatformAttestationMeasurement measurement = {};
-            ccf::pal::UVMEndorsements uvm_descriptor = {};
-            auto attestation = parse_and_verify_attestation(
-              in.attestation, report_data, measurement, uvm_descriptor);
-
-            if (attestation.format != ccf::QuoteFormat::insecure_virtual)
-            {
-              verify_against_platform_registration_policy(
-                ccfdns->platform_definition_auth(), uvm_descriptor);
-            }
-
-            auto platform = nlohmann::json(in.platform).dump();
-            ccfdns->set_platform_definition(platform, in.policy);
-
-            return ccf::make_success();
+            throw std::runtime_error("Missing service name (sub)");
           }
-          catch (std::exception& ex)
-          {
-            return ccf::make_error(
-              HTTP_STATUS_INTERNAL_SERVER_ERROR,
-              ccf::errors::InternalError,
-              ex.what());
-          }
-        };
+
+          ccfdns->set_platform_definition(platform, new_policy);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        }
+        catch (std::exception& ex)
+        {
+          ctx.rpc_ctx->set_response_body(ex.what());
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
+        }
+      };
 
       make_endpoint(
         "/set-platform-definition",
         HTTP_POST,
-        ccf::json_adapter(set_platform_definition),
+        set_platform_definition,
         ccf::no_auth_required)
-        .set_auto_schema<
-          SetPlatformDefinition::In,
-          SetPlatformDefinition::Out>()
-        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
+        .install();
+
+      auto set_service_definition_auth = [this](auto& ctx) {
+        try
+        {
+          ContextContext cc(ccfdns, ctx);
+          const auto& body = ctx.rpc_ctx->get_request_body();
+
+          auto as_cose = cose::decode_cose_request(body);
+          auto did = get_verified_did(as_cose);
+          auto policy = ccfdns->service_definition_auth();
+
+          verify_against_auth_policy(policy, did);
+
+          auto new_policy =
+            std::string(as_cose.payload.begin(), as_cose.payload.end());
+          CCF_APP_INFO("New policy is: {}", new_policy);
+
+          ccfdns->set_service_definition_auth(new_policy);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        }
+        catch (std::exception& ex)
+        {
+          ctx.rpc_ctx->set_response_body(ex.what());
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
+        }
+      };
+
+      make_endpoint(
+        "/set-service-definition-auth",
+        HTTP_POST,
+        set_service_definition_auth,
+        ccf::no_auth_required)
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
+        .install();
+
+      auto set_platform_definition_auth = [this](auto& ctx) {
+        try
+        {
+          ContextContext cc(ccfdns, ctx);
+          const auto& body = ctx.rpc_ctx->get_request_body();
+
+          auto as_cose = cose::decode_cose_request(body);
+          auto did = get_verified_did(as_cose);
+          auto policy = ccfdns->platform_definition_auth();
+
+          verify_against_auth_policy(policy, did);
+
+          auto new_policy =
+            std::string(as_cose.payload.begin(), as_cose.payload.end());
+          CCF_APP_INFO("New policy is: {}", new_policy);
+
+          ccfdns->set_platform_definition_auth(new_policy);
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+        }
+        catch (std::exception& ex)
+        {
+          ctx.rpc_ctx->set_response_body(ex.what());
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
+        }
+      };
+
+      make_endpoint(
+        "/set-platform-definition-auth",
+        HTTP_POST,
+        set_platform_definition_auth,
+        ccf::no_auth_required)
+        .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
         .install();
 
       auto ksk_txid_extractor =

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1298,9 +1298,9 @@ namespace aDNS
         r));
   }
 
-  void Resolver::configure(const Configuration& cfg)
+  void Resolver::configure()
   {
-    set_configuration(cfg);
+    auto cfg = get_configuration();
 
     update_nsec3_param(
       cfg.origin,
@@ -1314,8 +1314,6 @@ namespace aDNS
       throw std::runtime_error("missing node information");
 
     auto tls_key = get_tls_key();
-
-    RegistrationInformation out;
 
     remove(cfg.origin, cfg.origin, Class::IN, Type::SOA);
     add(cfg.origin, mk_rr(cfg.origin, Type::SOA, Class::IN, 60, SOA(cfg.soa)));

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1298,8 +1298,7 @@ namespace aDNS
         r));
   }
 
-  Resolver::RegistrationInformation Resolver::configure(
-    const Configuration& cfg)
+  void Resolver::configure(const Configuration& cfg)
   {
     set_configuration(cfg);
 
@@ -1317,9 +1316,6 @@ namespace aDNS
     auto tls_key = get_tls_key();
 
     RegistrationInformation out;
-
-    out.public_key = tls_key->public_key_pem().str();
-    out.node_information = get_node_information();
 
     remove(cfg.origin, cfg.origin, Class::IN, Type::SOA);
     add(cfg.origin, mk_rr(cfg.origin, Type::SOA, Class::IN, 60, SOA(cfg.soa)));
@@ -1351,49 +1347,6 @@ namespace aDNS
     // signs initial records; this triggers the creation of fresh DNSKEY
     // records.
     sign(cfg.origin);
-
-    std::string cn;
-    std::vector<ccf::crypto::SubjectAltName> sans;
-
-    cn = cfg.origin.unterminated();
-    sans.push_back({cn, false});
-    for (const auto& [id, addr] : cfg.node_addresses)
-      sans.push_back({addr.name.unterminated(), false});
-
-    if (cfg.alternative_names)
-      for (const auto& san : *cfg.alternative_names)
-        sans.push_back({san, false});
-
-    CCF_APP_INFO("CCFDNS: Resolver::configure(): CSR");
-    out.csr =
-      tls_key->create_csr_der("CN=" + cn, sans, tls_key->public_key_pem());
-
-    // get_signing_key(cfg.origin, Class::IN, cfg.use_key_signing_key);
-
-    CCF_APP_INFO("CCFDNS: Resolver::configure(): Resolve DNSKEY");
-    auto dnskeys = resolve(cfg.origin, QType::DNSKEY, QClass::IN);
-
-    if (dnskeys.answers.size() > 0)
-    {
-      out.dnskey_records = std::vector<ResourceRecord>();
-      for (const auto& keyrr : dnskeys.answers)
-        if (keyrr.type == static_cast<uint16_t>(Type::DNSKEY))
-        {
-          if (cfg.use_key_signing_key)
-          {
-            RFC4034::DNSKEY rd(keyrr.rdata);
-            if (rd.is_key_signing_key())
-              out.dnskey_records->push_back(keyrr);
-          }
-          else
-            out.dnskey_records->push_back(keyrr);
-        }
-    }
-    CCF_APP_INFO(
-      "CCFDNS: Resolver::configure(): Added {} records",
-      dnskeys.answers.size());
-
-    return out;
   }
 
   void Resolver::add_fragmented(

--- a/src/resolver.cpp
+++ b/src/resolver.cpp
@@ -1547,7 +1547,7 @@ namespace aDNS
     {
       try
       {
-        auto platform = nlohmann::json(phdr.cwt.att).dump();
+        auto platform = nlohmann::json(phdr.cwt.att).get<std::string>();
         verify_platform_definition(
           ccf::ds::to_hex(measurement.data), platform_definition(platform));
 

--- a/tests/adns_service.py
+++ b/tests/adns_service.py
@@ -2,9 +2,7 @@
 # Licensed under the Apache 2.0 License.
 
 import http
-import time
 import json
-import requests
 import infra.network
 from infra.interfaces import (
     RPCInterface,
@@ -13,9 +11,7 @@ from infra.interfaces import (
     HostSpec,
     PRIMARY_RPC_INTERFACE,
 )
-from loguru import logger as LOG
 
-DEFAULT_NODES = ["local://127.0.0.1:8080"]
 
 AUTH_POLICY_ALLOW_ALL = """
 package policy
@@ -72,32 +68,6 @@ class aDNSConfig(dict):
         self.nsec3_hash_algorithm = nsec3_hash_algorithm
         self.nsec3_hash_iterations = nsec3_hash_iterations
         self.nsec3_salt_length = nsec3_salt_length
-
-
-def configure(base_url, cabundle, config, client_cert=None, num_retries=10):
-    def success(r):
-        return (
-            r.status_code == http.HTTPStatus.OK
-            or r.status_code == http.HTTPStatus.NO_CONTENT
-        )
-
-    for _ in range(num_retries):
-        r = requests.post(
-            base_url + "/app/configure",
-            json.dumps(config),
-            timeout=60,
-            verify=cabundle,
-            headers={"Content-Type": "application/json"},
-            cert=client_cert,
-        )
-
-        if not success(r):
-            LOG.info(
-                f"Configuring failed with status code {r.status_code}: {r.text}, retrying..."
-            )
-            time.sleep(1)
-
-    assert success(r), r.text
 
 
 def set_policy(network, proposal_name, policy):

--- a/tests/adns_service.py
+++ b/tests/adns_service.py
@@ -92,7 +92,7 @@ def set_configuration(network, config):
     primary, _ = network.find_primary()
 
     proposal_body, careful_vote = network.consortium.make_proposal(
-        "set_configuration", new_config=config
+        "set_adns_configuration", new_config=config
     )
 
     proposal = network.consortium.get_any_active_member().propose(

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -336,7 +336,9 @@ function setServiceDefinitionAuth(new_policy) {
       getSingletonKvKey(),
     );
   if (current != undefined) {
-    throw new Error("Cannot overwrite service definition auth policy");
+    throw new Error(
+      "Governance can only be used to set initial service definition auth, subsequent updates must take place through /set-service-definition-auth",
+    );
   }
   ccf.kv["public:ccf.gov.ccfdns.service_definition_auth"].set(
     getSingletonKvKey(),
@@ -350,7 +352,9 @@ function setPlatformDefinitionAuth(new_policy) {
       getSingletonKvKey(),
     );
   if (current != undefined) {
-    throw new Error("Cannot overwrite platform definition auth policy");
+    throw new Error(
+      "Governance can only be used to set initial platform definition auth, subsequent updates must take place through /set-platform-definition-auth",
+    );
   }
   ccf.kv["public:ccf.gov.ccfdns.platform_definition_auth"].set(
     getSingletonKvKey(),
@@ -358,7 +362,7 @@ function setPlatformDefinitionAuth(new_policy) {
   );
 }
 
-function setConfiguration(new_config) {
+function setADNSConfiguration(new_config) {
   ccf.kv["public:ccf.gov.ccfdns.adns_configuration"].set(
     getSingletonKvKey(),
     ccf.strToBuf(new_config),
@@ -1426,13 +1430,13 @@ const actions = new Map([
     ),
   ],
   [
-    "set_configuration",
+    "set_adns_configuration",
     new Action(
       function (args) {
         checkType(args.new_config, "string", "new_config");
       },
       function (args) {
-        setConfiguration(args.new_config);
+        setADNSConfiguration(args.new_config);
       },
     ),
   ],

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -344,6 +344,13 @@ function setPlatformDefinitionAuth(new_policy) {
   );
 }
 
+function setConfiguration(new_config) {
+  ccf.kv["public:ccf.gov.ccfdns.adns_configuration"].set(
+    getSingletonKvKey(),
+    ccf.strToBuf(new_config),
+  );
+}
+
 const actions = new Map([
   [
     "set_constitution",
@@ -1401,6 +1408,17 @@ const actions = new Map([
       },
       function (args) {
         setPlatformDefinitionAuth(args.new_policy);
+      },
+    ),
+  ],
+  [
+    "set_configuration",
+    new Action(
+      function (args) {
+        checkType(args.new_config, "string", "new_config");
+      },
+      function (args) {
+        setConfiguration(args.new_config);
       },
     ),
   ],

--- a/tests/constitution/actions.js
+++ b/tests/constitution/actions.js
@@ -331,6 +331,13 @@ function updateServiceConfig(new_config) {
 }
 
 function setServiceDefinitionAuth(new_policy) {
+  let current =
+    ccf.kv["public:ccf.gov.ccfdns.service_definition_auth"].get(
+      getSingletonKvKey(),
+    );
+  if (current != undefined) {
+    throw new Error("Cannot overwrite service definition auth policy");
+  }
   ccf.kv["public:ccf.gov.ccfdns.service_definition_auth"].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(new_policy),
@@ -338,6 +345,13 @@ function setServiceDefinitionAuth(new_policy) {
 }
 
 function setPlatformDefinitionAuth(new_policy) {
+  let current =
+    ccf.kv["public:ccf.gov.ccfdns.platform_definition_auth"].get(
+      getSingletonKvKey(),
+    );
+  if (current != undefined) {
+    throw new Error("Cannot overwrite platform definition auth policy");
+  }
   ccf.kv["public:ccf.gov.ccfdns.platform_definition_auth"].set(
     getSingletonKvKey(),
     ccf.jsonCompatibleToBuf(new_policy),

--- a/tests/did_utils.py
+++ b/tests/did_utils.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the Apache 2.0 License.
+
+import base64
+import datetime
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from hashlib import sha256
+
+
+class Issuer:
+    def __init__(self, did, certs, private_key):
+        self.did = did
+        self.certs = certs
+        self.private_key = private_key
+
+
+def create_issuer(chain_length=2):
+    assert chain_length > 1
+
+    certs = []
+    private_keys = []
+    eku = "1.3.6.1.5.5.7.3.36"
+
+    for i in range(chain_length):
+        is_root = i == 0
+        is_leaf = i == chain_length - 1
+
+        # Generate private key
+        private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+        private_keys.append(private_key)
+
+        # Create certificate
+        subject = x509.Name(
+            [
+                x509.NameAttribute(
+                    NameOID.COMMON_NAME,
+                    (
+                        "Root CA"
+                        if is_root
+                        else (
+                            f"Intermediate CA {i}"
+                            if not is_leaf
+                            else "Leaf Certificate"
+                        )
+                    ),
+                ),
+            ]
+        )
+
+        issuer_name = subject if is_root else certs[-1].subject
+        signing_key = private_key if is_root else private_keys[i - 1]
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer_name)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+            .not_valid_after(
+                datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(days=365)
+            )
+        )
+
+        # Add extensions in the pattern you specified
+        subject_pub_key = private_key.public_key()
+        issuer_key = private_key if is_root else private_keys[i - 1]
+
+        cert = (
+            cert.add_extension(
+                x509.KeyUsage(
+                    digital_signature=not is_root,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=is_root,
+                    crl_sign=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=is_root, path_length=None), critical=True
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(subject_pub_key),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                    issuer_key.public_key()
+                ),
+                critical=False,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([x509.ObjectIdentifier(eku)]), critical=False
+            )
+        )
+
+        cert = cert.sign(signing_key, hashes.SHA256(), default_backend())
+        certs.append(cert)
+
+    root_cert_der = certs[0].public_bytes(serialization.Encoding.DER)
+    fingerprint = sha256(root_cert_der).digest()
+    fingerprint_b64url = base64.urlsafe_b64encode(fingerprint).decode().rstrip("=")
+
+    did_issuer = f"did:x509:0:sha256:{fingerprint_b64url}::eku:{eku}"
+    root_private_key = private_keys[0]
+
+    certs.reverse()
+    return Issuer(did_issuer, certs, root_private_key)

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -113,7 +113,7 @@ package policy
 default allow := false
 
 allowed_issuer if {{
-    input.iss == "{did}"
+    input.phdr.cwt.iss == "{did}"
 }}
 
 allow if {{

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -7,11 +7,12 @@ import base64
 import socket
 import requests
 import json
-import infra.e2e_args
+import infra.e2e_args  # type: ignore
 import os
 import time
 import subprocess
 import adns_service
+from did_utils import create_issuer
 import dns
 import dns.message
 import dns.query
@@ -103,6 +104,22 @@ def get_attestation(report_data, enclave, as_json=True):
             "uvm": uvm_endorsements,
         }
     )
+
+
+def get_policy_for_issuer(did):
+    return f"""
+package policy
+
+default allow := false
+
+allowed_issuer if {{
+    input.iss == "{did}"
+}}
+
+allow if {{
+    allowed_issuer
+}}
+"""
 
 
 def get_security_policy(enclave):
@@ -227,6 +244,49 @@ def cose_register_service_request(
     cose = COSE.new()
     return cose.encode_and_sign(
         protected=phdr, unprotected={}, payload=attestation, key=cose_key
+    )
+
+
+def create_cose_with_x5chain(issuer, payload, sub=None):
+    """Create COSE Sign1 message with X.509 certificate chain and issuer"""
+
+    # COSE header constants
+    PHDR_X5CHAIN = 33  # x5chain header parameter
+
+    # Build protected headers with full certificate chain (DER encoding for COSE)
+    cert_chain_der = []
+    for i, cert in enumerate(issuer.certs):
+        try:
+            der_bytes = cert.public_bytes(serialization.Encoding.DER)
+            cert_chain_der.append(der_bytes)
+            print(f"Certificate {i} DER length: {len(der_bytes)} bytes")
+        except Exception as e:
+            print(f"Error encoding certificate {i} to DER: {e}")
+            raise
+
+    phdr = {
+        PHDR_ALG: ALG_ES256,  # ES256 algorithm
+        PHDR_X5CHAIN: cert_chain_der,
+        PHDR_CWT: {
+            CWT_ISS: issuer.did,  # DID issuer (based on root cert fingerprint)
+        },
+    }
+
+    if sub:
+        phdr[PHDR_CWT][CWT_SUB] = sub
+
+    # Convert leaf private key to COSE key format (for signing)
+    pem_key = issuer.private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    cose_key = COSEKey.from_pem(pem_key)
+
+    # Create and sign COSE message
+    cose = COSE.new()
+    return cose.encode_and_sign(
+        protected=phdr, unprotected={}, payload=payload, key=cose_key
     )
 
 
@@ -427,46 +487,98 @@ def register_failed(with_error, *args, **kwargs):
         )
 
 
-def set_service_definition(network, enclave, service_name, permissive=True):
-    policy = get_service_definition(enclave=enclave, permissive=permissive)
+def set_service_definition(network, enclave, issuer, service_name, permissive=True):
     primary, _ = network.find_primary()
 
     # Let's hash policy as report data for now.
-    report_data = sha256(policy.encode()).digest()
+    policy = get_service_definition(enclave=enclave, permissive=permissive).encode()
+    reg_request = create_cose_with_x5chain(issuer, policy, service_name)
 
     with primary.client(identity="member0") as client:
         r = client.post(
             "/app/set-service-definition",
-            {
-                "service_name": service_name,
-                "policy": policy,
-                "attestation": get_attestation(
-                    report_data=report_data, enclave=enclave
-                ),
-            },
+            body=reg_request,
+            headers={"Content-Type": "application/cose"},
         )
-        assert r.status_code == http.HTTPStatus.NO_CONTENT, r
+        assert r.status_code == http.HTTPStatus.OK, r
 
 
-def set_platform_definition(network, enclave, platform, permissive=True):
-    policy = get_platform_definition(enclave=enclave, permissive=permissive)
+def set_platform_definition_auth(network, issuer, platform):
+    primary, _ = network.find_primary()
+
+    payload = get_policy_for_issuer(issuer.did).encode()
+    reg_request = create_cose_with_x5chain(issuer, payload, platform)
+
+    with primary.client(identity="member0") as client:
+        r = client.post(
+            "/app/set-platform-definition-auth",
+            body=reg_request,
+            headers={"Content-Type": "application/cose"},
+        )
+        assert r.status_code == http.HTTPStatus.OK, r
+
+
+def set_platform_definition_auth_successfully(*args, **kwargs):
+    set_platform_definition_auth(*args, **kwargs)
+
+
+def set_platform_definition_auth_failed(with_error, *args, **kwargs):
+    try:
+        set_platform_definition_auth(*args, **kwargs)
+    except Exception as e:
+        if with_error not in str(e):
+            raise AssertionError(f"Expected error '{with_error}' but got: {e}")
+    else:
+        raise AssertionError(
+            f"Expected failure with error '{with_error}' but succeeded"
+        )
+
+
+def set_service_definition_auth(network, issuer, service_name):
+    primary, _ = network.find_primary()
+
+    payload = get_policy_for_issuer(issuer.did).encode()
+    reg_request = create_cose_with_x5chain(issuer, payload, service_name)
+
+    with primary.client(identity="member0") as client:
+        r = client.post(
+            "/app/set-service-definition-auth",
+            body=reg_request,
+            headers={"Content-Type": "application/cose"},
+        )
+        assert r.status_code == http.HTTPStatus.OK, r
+
+
+def set_service_definition_auth_successfully(*args, **kwargs):
+    set_service_definition_auth(*args, **kwargs)
+
+
+def set_service_definition_auth_failed(with_error, *args, **kwargs):
+    try:
+        set_service_definition_auth(*args, **kwargs)
+    except Exception as e:
+        if with_error not in str(e):
+            raise AssertionError(f"Expected error '{with_error}' but got: {e}")
+    else:
+        raise AssertionError(
+            f"Expected failure with error '{with_error}' but succeeded"
+        )
+
+
+def set_platform_definition(network, enclave, issuer, platform, permissive=True):
     primary, _ = network.find_primary()
 
     # Let's hash policy as report data for now.
-    report_data = sha256(policy.encode()).digest()
+    policy = get_platform_definition(enclave=enclave, permissive=permissive).encode()
+    reg_request = create_cose_with_x5chain(issuer, policy, platform)
 
     with primary.client(identity="member0") as client:
         r = client.post(
             "/app/set-platform-definition",
-            {
-                "platform": platform,
-                "policy": policy,
-                "attestation": get_attestation(
-                    report_data=report_data, enclave=enclave
-                ),
-            },
+            body=reg_request,
+            headers={"Content-Type": "application/cose"},
         )
-        assert r.status_code == http.HTTPStatus.NO_CONTENT, r
+        assert r.status_code == http.HTTPStatus.OK, r
 
 
 def set_service_definition_successfully(*args, **kwargs):
@@ -508,11 +620,28 @@ def test_service_registration(network, args):
     enclave = args.enclave_platform
     service_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
 
+    issuer = create_issuer()
+
+    set_service_definition_auth_successfully(
+        network, issuer, "test.acidns10.attested.name."
+    )
+    set_platform_definition_auth_successfully(
+        network, issuer, get_attestation_format(enclave)
+    )
+
     set_service_definition_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", permissive=True
+        network,
+        enclave,
+        issuer,
+        service_name="test.acidns10.attested.name.",
+        permissive=True,
     )
     set_platform_definition_successfully(
-        network, enclave, platform=get_attestation_format(enclave), permissive=True
+        network,
+        enclave,
+        issuer,
+        platform=get_attestation_format(enclave),
+        permissive=True,
     )
 
     register_successfully(
@@ -527,7 +656,7 @@ def test_service_registration(network, args):
 
     # Different service name should fail, no policy for it.
     register_failed(
-        "no service relying party policy",
+        "no service definition",
         primary,
         enclave=enclave,
         service_name="another.acidns10.attested.name.",
@@ -536,10 +665,18 @@ def test_service_registration(network, args):
 
     # Register under wrong service registration policy (modified host data, aka security policy).
     set_service_definition_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", permissive=False
+        network,
+        enclave,
+        issuer,
+        service_name="test.acidns10.attested.name.",
+        permissive=False,
     )
     set_platform_definition_successfully(
-        network, enclave, platform=get_attestation_format(enclave), permissive=True
+        network,
+        enclave,
+        issuer,
+        platform=get_attestation_format(enclave),
+        permissive=True,
     )
     register_failed(
         "Policy not satisfied",
@@ -551,10 +688,18 @@ def test_service_registration(network, args):
 
     # Register under wrong platform registration policy (modified host data, aka security policy).
     set_service_definition_successfully(
-        network, enclave, service_name="test.acidns10.attested.name.", permissive=True
+        network,
+        enclave,
+        issuer,
+        service_name="test.acidns10.attested.name.",
+        permissive=True,
     )
     set_platform_definition_successfully(
-        network, enclave, platform=get_attestation_format(enclave), permissive=False
+        network,
+        enclave,
+        issuer,
+        platform=get_attestation_format(enclave),
+        permissive=False,
     )
     register_failed(
         "Policy not satisfied",

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -490,7 +490,6 @@ def register_failed(with_error, *args, **kwargs):
 def set_service_definition(network, enclave, issuer, service_name, permissive=True):
     primary, _ = network.find_primary()
 
-    # Let's hash policy as report data for now.
     policy = get_service_definition(enclave=enclave, permissive=permissive).encode()
     reg_request = create_cose_with_x5chain(issuer, policy, service_name)
 
@@ -568,7 +567,6 @@ def set_service_definition_auth_failed(with_error, *args, **kwargs):
 def set_platform_definition(network, enclave, issuer, platform, permissive=True):
     primary, _ = network.find_primary()
 
-    # Let's hash policy as report data for now.
     policy = get_platform_definition(enclave=enclave, permissive=permissive).encode()
     reg_request = create_cose_with_x5chain(issuer, policy, platform)
 

--- a/tests/e2e_basic.py
+++ b/tests/e2e_basic.py
@@ -739,7 +739,7 @@ def run(args):
 
     test_attestation(args)
 
-    adns_nw, _ = adns_service.run(
+    adns_nw = adns_service.run(
         args,
         tcp_port=53,
         udp_port=53,

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -948,7 +948,8 @@ TEST_CASE("Service registration")
        .ip = "127.0.0.1",
        .protocol = "tcp",
        .port = 53}}};
-  s.configure(cfg);
+  s.set_configuration(cfg);
+  s.configure();
 
   Name service_name("service42.example.com.");
 

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -427,7 +427,7 @@ default allow := true
 
     QCBOREncode_AddInt64ToMapN(&cbor_encode, 1, sign_ctx.cose_algorithm_id);
 
-    QCBOREncode_OpenMapInMapN(&cbor_encode, CWT_CLAIMS_LABEL); // > phdr.cwt
+    QCBOREncode_OpenMapInMapN(&cbor_encode, COSE_CWT_LABEL); // > phdr.cwt
 
     QCBOREncode_AddTextToMapN(
       &cbor_encode, CWT_ISS_LABEL, from_string(cwt_claims.iss));

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -966,7 +966,11 @@ TEST_CASE("Service registration")
   cose::ServiceInfo svi{.port = "443", .protocol = "tcp", .ipv4 = address};
 
   cose::CwtClaim cwt_claims{
-    .iss = url_name, .cnf = cnf, .att = get_attestation_type(), .svi = svi};
+    .iss = url_name,
+    .sub = {},
+    .cnf = cnf,
+    .att = get_attestation_type(),
+    .svi = svi};
 
   auto rr = s.create_cose_sign1(cwt_claims, s.get_service_key());
   s.register_service(rr);

--- a/tests/run_adns.py
+++ b/tests/run_adns.py
@@ -251,7 +251,7 @@ def set_policies(network, args):
 def run(args):
     """Run tests"""
 
-    adns_nw, _ = adns_service.run(
+    adns_nw = adns_service.run(
         args,
         tcp_port=5353,
         udp_port=5353,


### PR DESCRIPTION
Resolves https://github.com/microsoft/ccfdns/issues/66

- [x] Simplify aDNS config, remove unused things
- [x] Set initial config as proposal
- [x] `/configure` now has no input, reads KV and applies the configuration set (feel free to suggest other options)
- [x] Set **initial only** `service_auth` and `platform_auth` as proposal
- [x] COSE endpoints for `service_auth` and `platform_auth` verified against current `service_auth` and `platform_auth` respectively
- [x] `cose.h` parsing utils now set all fields optionally to support multiple various requests types
- [x] `x5chain` support added
- [x] `did` parsing as `phdr`
- [x] e2e tests adapted accordingly 

Note. `auth` policies are per instance, `definition` policies are per service/platform.