### PR TITLE
Update ccfdns platform policy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,6 @@ RUN gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY  \
     && tdnf -y update  \
     && tdnf -y install ca-certificates
     
-RUN curl -L https://github.com/microsoft/CCF/releases/download/ccf-6.0.3/ccf_virtual_devel_6.0.3_x86_64.rpm -o ccf-devel.rpm  \
+RUN curl -L https://github.com/microsoft/CCF/releases/download/ccf-6.0.14/ccf_virtual_devel_6.0.14_x86_64.rpm -o ccf-devel.rpm  \
     && tdnf -y install ./ccf-devel.rpm
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,14 +55,14 @@ jobs:
       - uses: robinraju/release-downloader@v1
         with:
           repository: "microsoft/CCF"
-          tag: "ccf-6.0.3"
-          fileName: "ccf_virtual_devel_6.0.3_x86_64.rpm"
+          tag: "ccf-6.0.14"
+          fileName: "ccf_virtual_devel_6.0.14_x86_64.rpm"
 
       - name: "Install CCF with dependencies"
         shell: bash
         run: |
           set -ex
-          tdnf -y install ccf_virtual_devel_6.0.3_x86_64.rpm
+          tdnf -y install ccf_virtual_devel_6.0.14_x86_64.rpm
           ./scripts/setup-ci.sh
 
       - name: Build ADNS

--- a/demo/adns/adns.sh
+++ b/demo/adns/adns.sh
@@ -30,6 +30,7 @@ export VENV_DIR="$VENV_DIR"
 export BETTER_EXCEPTIONS=1
 
 CCF_DIR="/opt/$(ls /opt | grep ccf_ | head -1)"
-export PYTHONPATH=$PYTHONPATH:$CCF_DIR/bin
+export PYTHONPATH=$PYTHONPATH:$CCF_DIR/bin:../../
+export SNP_REPORT_BINARY=../../3rdparty/get-snp-report/bin/get-snp-report
 
 python3 ../../tests/run_adns.py -b "$CCF_DIR/bin" --library-dir ../../build

--- a/demo/client/ksk.py
+++ b/demo/client/ksk.py
@@ -5,7 +5,7 @@ import time
 import json
 import tempfile
 from http import HTTPStatus
-from tools.attestation import verify_snp_attestation
+from tools.attestation import verify_snp_attestation, pack_tcb
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -13,7 +13,6 @@ from cryptography import x509
 from hashlib import sha256
 import dns
 from regopy import Interpreter
-import struct
 import subprocess
 from ccf.receipt import root as reconstruct_root
 from ccf.receipt import verify as verify_receipt_ccf
@@ -245,12 +244,6 @@ SERVICE_POLICY = """
         host_data_valid
     }
 """
-
-
-def pack_tcb(tcb):
-    return struct.pack(
-        "<BB4sBB", tcb.bootloader, tcb.tee, tcb._reserved, tcb.snp, tcb.microcode
-    )
 
 
 def check_policy(policy, policy_input):

--- a/demo/client/ksk.py
+++ b/demo/client/ksk.py
@@ -203,7 +203,7 @@ PLATFORM_POLICY = """
         input.attestation.product_name == "Milan"
     }
     reported_tcb_valid if {
-        input.attestation.reported_tcb.hexstring == "04000000000018db"
+        input.attestation.reported_tcb.hexstring == "db18000000000004"
     }
     amd_tcb_valid if {
         product_name_valid

--- a/demo/server/service.sh
+++ b/demo/server/service.sh
@@ -23,6 +23,6 @@ export VENV_DIR="$VENV_DIR"
 export BETTER_EXCEPTIONS=1
 
 CCF_DIR="$(ls /opt | grep ccf_ | head -1)"
-export PYTHONPATH=$PYTHONPATH:/opt/$CCF_DIR/bin:../../tests
+export PYTHONPATH=$PYTHONPATH:/opt/$CCF_DIR/bin:../../tests:../../
 
 python3 service.py --dns-name test.e2e.acidns10.attested.name --port 443 --adns $ADNS_URL

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -11,7 +11,7 @@ tdnf -y install ca-certificates  \
 # Check if CCF is already installed under /opt
 if [ ! -d "/opt/ccf_${PLATFORM}" ]; then
     echo "CCF not found, downloading and installing..."
-    curl -L https://github.com/microsoft/CCF/releases/download/ccf-6.0.3/ccf_${PLATFORM}_devel_6.0.3_x86_64.rpm -o ccf-devel.rpm  \
+    curl -L https://github.com/microsoft/CCF/releases/download/ccf-6.0.14/ccf_${PLATFORM}_devel_6.0.14_x86_64.rpm -o ccf-devel.rpm  \
         && tdnf -y install ./ccf-devel.rpm
 else
     echo "CCF already installed at /opt/ccf_${PLATFORM}"

--- a/scripts/setup-ci.sh
+++ b/scripts/setup-ci.sh
@@ -12,3 +12,6 @@ tdnf -y install zlib-devel  \
     python-pip  \
     git  \
     npm
+
+# Temporary fixup. Find out why ccf 6.0.14 doesn't provide this deps
+tdnf -y install libuv-devel libcurl-devel

--- a/tests/adns_attestation.py
+++ b/tests/adns_attestation.py
@@ -1,13 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the Apache 2.0 License.
 
-import struct
 import sys
 import cbor2
 import base64
 from regopy import Interpreter
-
-from tools.attestation import verify_snp_attestation
+from tools.attestation import verify_snp_attestation, pack_tcb
 
 
 PLATFORM_POLICY = """
@@ -59,12 +57,6 @@ SERVICE_POLICY = """
         host_data_valid
     }
 """
-
-
-def pack_tcb(tcb):
-    return struct.pack(
-        "<BB4sBB", tcb.bootloader, tcb.tee, tcb._reserved, tcb.snp, tcb.microcode
-    )
 
 
 def check_policy(policy, policy_input):

--- a/tools/attestation.py
+++ b/tools/attestation.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cwt import COSE, COSEKey
 from didx509.didx509 import resolve_did
+import struct
 
 
 def get_issuer_cn(cert):
@@ -132,3 +133,14 @@ def verify_snp_attestation(attestation, endorsements, uvm_endorsements):
     assert report.measurement.hex() == measurement
 
     return product_name, report, did, feed, svn
+
+
+def pack_tcb(tcb):
+    return struct.pack(
+        "<BB4sBB",
+        tcb.microcode,
+        tcb.snp,
+        tcb._reserved,
+        tcb.tee,
+        tcb.bootloader,
+    )


### PR DESCRIPTION
Make it up to date with demo policies. Required upgrading to ccf **6.0.14** for the sake of newer attestation API.